### PR TITLE
fix #6 by migrating to latest swift syntax

### DIFF
--- a/swift-coverage/swift-coverage-example/swift-coverage-example.xcodeproj/project.pbxproj
+++ b/swift-coverage/swift-coverage-example/swift-coverage-example.xcodeproj/project.pbxproj
@@ -140,9 +140,11 @@
 				TargetAttributes = {
 					44AA04781D6488A000008699 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 					};
 					44AA04871D6488A100008699 = {
 						CreatedOnToolsVersion = 7.3.1;
+						LastSwiftMigration = 0830;
 						TestTargetID = 44AA04781D6488A000008699;
 					};
 				};
@@ -315,6 +317,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "sonar.swift-coverage-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Debug;
 		};
@@ -327,6 +330,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "sonar.swift-coverage-example";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 			};
 			name = Release;
 		};
@@ -339,6 +343,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "sonar.swift-coverage-exampleTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/swift-coverage-example.app/Contents/MacOS/swift-coverage-example";
 			};
 			name = Debug;
@@ -352,6 +357,7 @@
 				LD_RUNPATH_SEARCH_PATHS = "$(inherited) @executable_path/../Frameworks @loader_path/../Frameworks";
 				PRODUCT_BUNDLE_IDENTIFIER = "sonar.swift-coverage-exampleTests";
 				PRODUCT_NAME = "$(TARGET_NAME)";
+				SWIFT_VERSION = 3.0;
 				TEST_HOST = "$(BUILT_PRODUCTS_DIR)/swift-coverage-example.app/Contents/MacOS/swift-coverage-example";
 			};
 			name = Release;
@@ -375,6 +381,7 @@
 				44AA04931D6488A100008699 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 		44AA04941D6488A100008699 /* Build configuration list for PBXNativeTarget "swift-coverage-exampleTests" */ = {
 			isa = XCConfigurationList;
@@ -383,6 +390,7 @@
 				44AA04961D6488A100008699 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
 		};
 /* End XCConfigurationList section */
 	};

--- a/swift-coverage/swift-coverage-example/swift-coverage-example/AppDelegate.swift
+++ b/swift-coverage/swift-coverage-example/swift-coverage-example/AppDelegate.swift
@@ -14,11 +14,11 @@ class AppDelegate: NSObject, NSApplicationDelegate {
     @IBOutlet weak var window: NSWindow!
 
 
-    func applicationDidFinishLaunching(aNotification: NSNotification) {
+    func applicationDidFinishLaunching(_ aNotification: Notification) {
         // Insert code here to initialize your application
     }
 
-    func applicationWillTerminate(aNotification: NSNotification) {
+    func applicationWillTerminate(_ aNotification: Notification) {
         // Insert code here to tear down your application
     }
 

--- a/swift-coverage/swift-coverage-example/swift-coverage-exampleTests/swift_coverage_exampleTests.swift
+++ b/swift-coverage/swift-coverage-example/swift-coverage-exampleTests/swift_coverage_exampleTests.swift
@@ -28,7 +28,7 @@ class swift_coverage_exampleTests: XCTestCase {
     
     func testPerformanceExample() {
         // This is an example of a performance test case.
-        self.measureBlock {
+        self.measure {
             // Put the code you want to measure the time of here.
         }
     }


### PR DESCRIPTION
The swift example project did not work upon checking out, because new swift syntax is available. I converted the example project to the newer version of swift, so now it work out-of-the box.