### PR TITLE
Add script for XCode 9.3+ coverage

### DIFF
--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -16,11 +16,11 @@ Usage
 `xcodebuild -project swift-coverage-example.xcodeproj/ -scheme swift-coverage-example -derivedDataPath Build/ -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO`
 
 1.b Create code coverage report
-**Note** : The <device_id> used in the below command can be found from the XCode tools command: instruments -s devices
+
+**Note** : The <device_id> used in the below command can be found from the XCode tools command: `instruments -s devices`
 
 XCode version | Command
 --- | ---
-XCode 7.x (or older) | `xcrun llvm-cov show -instr-profile=Build/Intermediates/CodeCoverage/Coverage.profdata Build/Intermediates/CodeCoverage/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
 XCode 8+ - 9.2 | `xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
 XCode 9.3+ | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
 
@@ -28,7 +28,7 @@ XCode 9.3+ | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/
 
 XCode version | Command
 --- | ---
-XCode 7.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true`
+XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true`
 XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true`
-  
+
 2. Verify that for the project "swift-coverage-example" the coverage value is 69.2%.

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -10,11 +10,16 @@ Usage
 =====
 
 1. Run from "swift-coverage-example"
-  * xcodebuild -scheme swift-coverage-example -enableCodeCoverage YES -derivedDataPath . clean build test
-  * With XCode 7.x and older: xcrun llvm-cov show -instr-profile=Build/Intermediates/CodeCoverage/Coverage.profdata Build/Intermediates/CodeCoverage/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report
-  * With XCode 8+, 9+: xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report
- 
-  The <device_id> can be found from the XCode tools command: instruments -s devices
+
+**Note** : The <device_id> used in the below command can be found from the XCode tools command: instruments -s devices
+
+XCode version | Command
+--- | ---
+All versions | xcodebuild -scheme swift-coverage-example -enableCodeCoverage YES -derivedDataPath . clean build test
+XCode 7.x (or older) | xcrun llvm-cov show -instr-profile=Build/Intermediates/CodeCoverage/Coverage.profdata Build/Intermediates/CodeCoverage/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report
+XCode 8+ - 9.2 | xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report
+XCode 9.3+ | bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml
+XCode 7.x - 9.2 | sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true
+XCode 9.3+ | sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true
   
-  * sonar-scanner
-2. Verify that for the project "swift-coverage-example" the coverage value is 60%.
+2. Verify that for the project "swift-coverage-example" the coverage value is 69.2%.

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -11,15 +11,24 @@ Usage
 
 1. Run from "swift-coverage-example"
 
+1.a Build project
+
+`xcodebuild -project swift-coverage-example.xcodeproj/ -scheme swift-coverage-example -derivedDataPath Build/ -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO`
+
+1.b Create code coverage report
 **Note** : The <device_id> used in the below command can be found from the XCode tools command: instruments -s devices
 
 XCode version | Command
 --- | ---
-All versions | xcodebuild -scheme swift-coverage-example -enableCodeCoverage YES -derivedDataPath . clean build test
-XCode 7.x (or older) | xcrun llvm-cov show -instr-profile=Build/Intermediates/CodeCoverage/Coverage.profdata Build/Intermediates/CodeCoverage/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report
-XCode 8+ - 9.2 | xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report
-XCode 9.3+ | bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml
-XCode 7.x - 9.2 | sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true
-XCode 9.3+ | sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true
+XCode 7.x (or older) | `xcrun llvm-cov show -instr-profile=Build/Intermediates/CodeCoverage/Coverage.profdata Build/Intermediates/CodeCoverage/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
+XCode 8+ - 9.2 | `xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
+XCode 9.3+ | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
+
+1.b Import code coverage report
+
+XCode version | Command
+--- | ---
+XCode 7.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true`
+XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true`
   
 2. Verify that for the project "swift-coverage-example" the coverage value is 69.2%.

--- a/swift-coverage/swift-coverage-example/.gitignore
+++ b/swift-coverage/swift-coverage-example/.gitignore
@@ -1,0 +1,6 @@
+ModuleCache.noindex
+Index/
+Logs/
+Build/
+.scannerwork
+sonarqube-generic-coverage.xml

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -1,0 +1,26 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function convert_file {
+  local xccovarchive_file="$1"
+  local file_name="$2"
+  echo "  <file path=\"$file_name\">"
+  xcrun xccov view --file "$file_name" "$xccovarchive_file" | \
+    sed -n '
+    s/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p;
+    s/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p
+    '
+  echo '  </file>'
+}
+
+function xccov_to_generic {
+  echo '<coverage version="1">'
+  for xccovarchive_file in "$@"; do
+    xcrun xccov view --file-list "$xccovarchive_file" | while read -r file_name; do
+      convert_file "$xccovarchive_file" "$file_name"
+    done
+  done
+  echo '</coverage>'
+}
+
+xccov_to_generic "$@"


### PR DESCRIPTION
This script is present in this [SONARSWIFT-371](https://jira.sonarsource.com/browse/SONARSWIFT-371) and is pointed to in [Swift Coverage Results Import](https://docs.sonarqube.org/display/PLUG/Swift+Coverage+Results+Import)