### PR TITLE
Remove usages of sonar.language

### DIFF
--- a/sonarqube-scanner-ant/build.xml
+++ b/sonarqube-scanner-ant/build.xml
@@ -13,7 +13,6 @@
 	<property name="sonar.projectKey" value="org.sonarqube:sonarqube-scanner-ant" />
 	<property name="sonar.projectName" value="Example of SonarQube Scanner for Ant Usage" />
 	<property name="sonar.projectVersion" value="1.0" />
-	<property name="sonar.language" value="java" />
 	<property name="sonar.sources" value="src" />
 	<property name="sonar.binaries" value="target" />
 	<property name="sonar.sourceEncoding" value="UTF-8" />

--- a/sonarqube-scanner-build-wrapper-linux/sonar-project.properties
+++ b/sonarqube-scanner-build-wrapper-linux/sonar-project.properties
@@ -4,8 +4,6 @@ sonar.projectVersion=1.0
 
 sonar.sources=src
 
-sonar.language=cpp
-
 # The build-wrapper output dir
 sonar.cfamily.build-wrapper-output=bw-outputs
 


### PR DESCRIPTION
sonar.language is deprecated and there's a plan to drop it entirely (https://jira.sonarsource.com/browse/SONAR-11449). We should remove examples of it from this repo.