### PR TITLE
Fix parse error on missing brace

### DIFF
--- a/swift-coverage/swift-coverage-example/swift-coverage-exampleTests/swift_coverage_exampleTests.swift
+++ b/swift-coverage/swift-coverage-example/swift-coverage-exampleTests/swift_coverage_exampleTests.swift
@@ -30,6 +30,7 @@ class swift_coverage_exampleTests: XCTestCase {
         self.measure {
             // Put the code you want to measure the time of here.
         }
+    }
 
     func testFoo2() {
         AB().foo()


### PR DESCRIPTION
PR to fix an error where the build fails when using Xcode 10.x:

```
sonar-scanning-examples/swift-coverage/swift-coverage-example/swift-coverage-exampleTests/swift_coverage_exampleTests.swift:12:47: note: to match this opening '{'
class swift_coverage_exampleTests: XCTestCase {
                                              ^

2019-04-29 16:46:55.323 xcodebuild[70931:1174132]  DVTAssertions: Warning in /Library/Caches/com.apple.xbs/Sources/IDEFrameworks/IDEFrameworks-14490.120/IDEFoundation/Logging/ActivityLog/IDEActivityLogSectionRecorder.m:1050
Details:  log recorder was sent -stopRecordingWithInfo:completionBlock: after it had already been asked to stop recording.
Object:   <IDEActivityLogSectionRecorder: 0x7fa447bb1940>
Method:   -stopRecordingWithInfo:completionBlock:
Thread:   <NSThread: 0x7fa4471f9a20>{number = 10, name = (null)}
Please file a bug at https://bugreport.apple.com with this warning message and any useful information you can provide.

Testing failed:
	Expected '}' in class
	Testing cancelled because the build failed.

Test session results and logs:
	/var/jenkins/src/sonar-scanning-examples/swift-coverage/swift-coverage-example/Build/Logs/Test/Run-swift-coverage-example-2019.04.29_16-46-40--0700.xcresult

** TEST FAILED **
```