### PR TITLE
Add version for build-helper-maven-plugin

### DIFF
--- a/sonarqube-scanner-maven/app-groovy/pom.xml
+++ b/sonarqube-scanner-maven/app-groovy/pom.xml
@@ -30,6 +30,7 @@
 			<plugin>
 				<groupId>org.codehaus.mojo</groupId>
 				<artifactId>build-helper-maven-plugin</artifactId>
+				<version>3.0.0</version>
 				<executions>
 					<execution>
 						<phase>generate-sources</phase>


### PR DESCRIPTION
Fix warnings in Maven build:

```
$ pwd
/Users/mincong/github/sonar-scanning-examples/sonarqube-scanner-maven
$ mvn clean install
[INFO] Scanning for projects...
[WARNING]
[WARNING] Some problems were encountered while building the effective model for org.sonarqube:app-groovy:jar:1.0-SNAPSHOT
[WARNING] 'build.plugins.plugin.version' for org.codehaus.mojo:build-helper-maven-plugin is missing. @ org.sonarqube:app-groovy:[unknown-version], /Users/mincong/github/sonar-scanning-examples/sonarqube-scanner-maven/app-groovy/pom.xml, line 30, column 12
[WARNING]
[WARNING] It is highly recommended to fix these problems because they threaten the stability of your build.
[WARNING]
[WARNING] For this reason, future Maven versions might no longer support building such malformed projects.
[WARNING]
```