### PR TITLE
Setting Java source and target to 8 so 11 isn't required

### DIFF
--- a/sonarqube-scanner-maven/maven-multimodule/pom.xml
+++ b/sonarqube-scanner-maven/maven-multimodule/pom.xml
@@ -19,7 +19,8 @@
   <properties>
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
-    <maven.compiler.release>11</maven.compiler.release>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <maven.compiler.source>1.8</maven.compiler.source>
     <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
   </properties>
 


### PR DESCRIPTION
Give this a shot @cameronschmidt and merge if happy. For me this builds using either JDK 8 or 11.