### PR TITLE
Update xccov-to-sonarqube-generic.sh for xcode 11

### DIFF
--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -23,7 +23,8 @@ XCode version | Command
 --- | ---
 XCode 8+ - 9.2 | `xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
 XCode 9.3 - 9.4.1 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
-XCode 10+ | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/*_Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
+XCode 10 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/*_Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
+XCode 11 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml`
 
 1.c Import code coverage report
 

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -5,7 +5,12 @@ function convert_file {
   local xccovarchive_file="$1"
   local file_name="$2"
   echo "  <file path=\"$file_name\">"
-  xcrun xccov view --file "$file_name" "$xccovarchive_file" | \
+  local line_coverage_cmd="xcrun xccov view"
+  if [[ $@ == *".xcresult"* ]]; then
+    line_coverage_cmd="$line_coverage_cmd --archive"
+  fi
+  line_coverage_cmd="$line_coverage_cmd --file \"$file_name\" \"$xccovarchive_file\""
+  eval $line_coverage_cmd | \
     sed -n '
     s/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p;
     s/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p
@@ -16,7 +21,12 @@ function convert_file {
 function xccov_to_generic {
   echo '<coverage version="1">'
   for xccovarchive_file in "$@"; do
-    xcrun xccov view --file-list "$xccovarchive_file" | while read -r file_name; do
+    local file_list_cmd="xcrun xccov view"
+    if [[ $@ == *".xcresult"* ]]; then
+      file_list_cmd="$file_list_cmd --archive"
+    fi
+    file_list_cmd="$file_list_cmd --file-list \"$xccovarchive_file\""
+    eval $file_list_cmd | while read -r file_name; do
       convert_file "$xccovarchive_file" "$file_name"
     done
   done


### PR DESCRIPTION
This PR would make xccov-to-sonarqube-generic.sh work with Xcode 11 (see #63)  while not changing anything for previous versions.