### PR TITLE
Update to Gradle 6.4.1 to add JDK14 compatibility

### DIFF
--- a/sonarqube-scanner-gradle/gradle/wrapper/gradle-wrapper.properties
+++ b/sonarqube-scanner-gradle/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-5.2.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.4.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Updates Gradle from 5.2.1 to 6.4.1. This mainly allows the Gradle scanning example to run on systems using JDK versions 12, 13 and 14 - as 5.2.1 fails. 

Gradle 6.4.1 is [compatible with JDK8 onwards](https://gradle.org/install/).