### PR TITLE
Fix SonarScanner invocation command warning

### DIFF
--- a/sonarqube-scanner-msbuild/CSharpProject/README.md
+++ b/sonarqube-scanner-msbuild/CSharpProject/README.md
@@ -1,22 +1,22 @@
-This example demonstrates how to analyze a .NET Solution with the SonarQube Scanner for MSBuild.
+This example demonstrates how to analyze a .NET Solution with the SonarScanner for MSBuild.
 
 Prerequisites
 =============
-* [SonarQube](http://www.sonarqube.org/downloads/) 5.6+ LTS
-* [SonarQube Scanner for MSBuild](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+MSBuild) 2.2.0+
-* [SonarSource C# Plugin](http://redirect.sonarsource.com/plugins/csharp.html) 5.5.1+
-* [Compatible .NET Build Environment](http://docs.sonarqube.org/display/SCAN/From+the+Command+Line)
+* [SonarQube](http://www.sonarqube.org/downloads/) 7.9+ LTS
+* [SonarScanner for MSBuild](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+MSBuild) 4.1.0+
+* [SonarSource C# Plugin](http://redirect.sonarsource.com/plugins/csharp.html) 7.15+
+* [Compatible .NET Build Environment](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-msbuild/)
 
 Usage
 =====
-* Run SonarQube Scanner for MSBuild begin phase:
+* Run SonarScanner for MSBuild begin phase:
 
-        SonarQube.Scanner.MSBuild.exe begin /k:"org.sonarqube:sonarqube-scanner-msbuild" /n:"Example of SonarQube Scanner for MSBuild Usage" /v:"1.0"
+        SonarScanner.MSBuild.exe begin /k:"org.sonarqube:sonarqube-scanner-msbuild" /n:"Example of SonarScanner for MSBuild Usage" /v:"1.0"
 
 * Build the project with MSBuild:
 
         MSBuild.exe /t:Rebuild
 
-* Run SonarQube Scanner for MSBuild end phase:
+* Run SonarScanner for MSBuild end phase:
 
-        SonarQube.Scanner.MSBuild.exe end
+        SonarScanner.MSBuild.exe end


### PR DESCRIPTION
Fixes the warning message "_This executable is deprecated and may be removed in next major version of the SonarScanner for MSBuild. Please use 'SonarScanner.MSBuild.exe' instead_".

Relates to: https://github.com/SonarSource/sonar-scanner-msbuild/issues/429 (merged in March 2018).

Fixes broken link to Compatible .NET Build Environment docs site.

Bump old versions in compatibility list to 7.9 LTS compatible scanner and plugin versions.