### PR TITLE
Update README.md

### DIFF
--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -31,6 +31,6 @@ XCode 11 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > son
 XCode version | Command
 --- | ---
 XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true`
-XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true`
+XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true`
 
 2. Verify that for the project "swift-coverage-example" the coverage value is 69.2%.


### PR DESCRIPTION
`sonar.swift.coverage.reportPath` or `sonar.coverageReportPaths` is [not working on SonarCloud](https://community.sonarsource.com/t/sonarcloud-for-swift-java-io-ioexception-is-a-directory/27552)