### PR TITLE
Minor doc updates, add Table of Contents

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ bw-outputs/
 
 # mac
 .DS_Store
+
+# MSBuild
+obj/

--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@
 
 [SonarQube-Scanner-Maven Multi-Module](sonarqube-scanner-maven/maven-multimodule/)
 
-[SonarQube-Scanner-MSBuild CSharp](sonarqube-scanner-msbuild/)
+[SonarQube-Scanner-MSBuild CSharp](sonarqube-scanner-msbuild/CSharpProject/)
 
 [SonarQube-Scanner-Swift Code Coverage](swift-coverage/)
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,30 @@
-### License
+# SonarQube Scanning Examples
+
+[SonarQube SonarScanner](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/) scanning and code coverage import examples for various languages and build tools.
+
+[SonarQube-Scanner](sonarqube-scanner/README.md)
+
+## Examples
+
+[Java - Jacoco Code Coverage](doc/jacoco.md)
+
+[Objective-C - LLVM Coverage](objc-llvm-coverage/README.md)
+
+[SonarQube-Scanner-Ant](sonarqube-scanner-ant/README.md)
+
+[SonarQube-Scanner-Build-Wrapper-Linux](sonarqube-scanner-build-wrapper-linux/README.md)
+
+[SonarQube-Scanner-Gradle](sonarqube-scanner-gradle/README.md)
+
+[SonarQube-Scanner-Maven](sonarqube-scanner-maven/maven-basic/README.md)
+
+[SonarQube-Scanner-Maven Multi-Module](sonarqube-scanner-maven/maven-multimodule/README.md)
+
+[SonarQube-Scanner-MSBuild CSharp](sonarqube-scanner-msbuild/README.md)
+
+[SonarQube-Scanner-Swift Code Coverage](swift-coverage/README.md)
+
+## License
 
 Copyright 2016-2020 SonarSource.
 

--- a/README.md
+++ b/README.md
@@ -2,27 +2,27 @@
 
 [SonarQube SonarScanner](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner/) scanning and code coverage import examples for various languages and build tools.
 
-[SonarQube-Scanner](sonarqube-scanner/README.md)
-
 ## Examples
+
+[SonarQube-Scanner with various languages](sonarqube-scanner/)
 
 [Java - Jacoco Code Coverage](doc/jacoco.md)
 
-[Objective-C - LLVM Coverage](objc-llvm-coverage/README.md)
+[Objective-C - LLVM Coverage](objc-llvm-coverage/)
 
-[SonarQube-Scanner-Ant](sonarqube-scanner-ant/README.md)
+[SonarQube-Scanner-Ant](sonarqube-scanner-ant/)
 
-[SonarQube-Scanner-Build-Wrapper-Linux](sonarqube-scanner-build-wrapper-linux/README.md)
+[SonarQube-Scanner-Build-Wrapper-Linux](sonarqube-scanner-build-wrapper-linux/)
 
-[SonarQube-Scanner-Gradle](sonarqube-scanner-gradle/README.md)
+[SonarQube-Scanner-Gradle](sonarqube-scanner-gradle/)
 
-[SonarQube-Scanner-Maven](sonarqube-scanner-maven/maven-basic/README.md)
+[SonarQube-Scanner-Maven](sonarqube-scanner-maven/maven-basic/)
 
-[SonarQube-Scanner-Maven Multi-Module](sonarqube-scanner-maven/maven-multimodule/README.md)
+[SonarQube-Scanner-Maven Multi-Module](sonarqube-scanner-maven/maven-multimodule/)
 
-[SonarQube-Scanner-MSBuild CSharp](sonarqube-scanner-msbuild/README.md)
+[SonarQube-Scanner-MSBuild CSharp](sonarqube-scanner-msbuild/)
 
-[SonarQube-Scanner-Swift Code Coverage](swift-coverage/README.md)
+[SonarQube-Scanner-Swift Code Coverage](swift-coverage/)
 
 ## License
 

--- a/doc/jacoco.md
+++ b/doc/jacoco.md
@@ -2,7 +2,7 @@
 
 Version 5.12 of our SonarJava analyzer deprecated use JaCoCo's binary format (`.exec` files) to import coverage. This binary format is internal to the JaCoCo project, and as such there are no guarantees for backward compatibility, so it should not be used for integration purposes.
 
-As a replacment, we developed the [sonar-jacoco](https://docs.sonarqube.org/display/PLUG/JaCoCo+Plugin) plugin, which imports JaCoCo's XML coverage report, and this is the preferred option now. In this guide, I will describe how to import this XML report in some common scenarios.
+As a replacement, we developed the [sonar-jacoco](https://docs.sonarqube.org/display/PLUG/JaCoCo+Plugin) plugin, which imports JaCoCo's XML coverage report, and this is the preferred option now. In this guide, I will describe how to import this XML report in some common scenarios.
 
 You can find sample projects using the setup described here in [this repository](https://github.com/SonarSource/sonar-scanning-examples).
 

--- a/doc/jacoco.md
+++ b/doc/jacoco.md
@@ -1,6 +1,6 @@
 # Importing JaCoCo coverage report in XML format
 
-Version 5.12 of our SonarJava analyzer deprecated use JaCoCo's binary format (`.exec` files) to import coverage. This binary format is internal to the JaCoCo project, and as such there are no guarantees for backward compatibility, so it should not be used for integration purposes. 
+Version 5.12 of our SonarJava analyzer deprecated use JaCoCo's binary format (`.exec` files) to import coverage. This binary format is internal to the JaCoCo project, and as such there are no guarantees for backward compatibility, so it should not be used for integration purposes.
 
 As a replacment, we developed the [sonar-jacoco](https://docs.sonarqube.org/display/PLUG/JaCoCo+Plugin) plugin, which imports JaCoCo's XML coverage report, and this is the preferred option now. In this guide, I will describe how to import this XML report in some common scenarios.
 
@@ -47,13 +47,13 @@ Here is an example of such a profile
 
 By default the generated report will be saved under `target/site/jacoco/jacoco.xml`; this location will be checked automatically by the sonar-jacoco plugin so no further configuration is required. Just launch `mvn sonar:sonar` as usual and the report will be picked up.
 
-If you need to change the directory where the report has been generated you can set the property either on the command line using maven's  `-D` switch 
+If you need to change the directory where the report has been generated you can set the property either on the command line using maven's  `-D` switch
 
-```
+```shell
 mvn -Dsonar.coverage.jacoco.xmlReportPaths=report1.xml,report2.xml sonar:sonar 
 ```
 
-or you can set the property inside your `pom.xml` 
+or you can set the property inside your `pom.xml`
 
 ```xml
     <properties>
@@ -66,11 +66,11 @@ or you can set the property inside your `pom.xml`
 
 With multi-module builds, we sometimes need to show coverage across modules. For example, we might have multiple modules implementing business logic and another module which contains integration tests for all these modules. We would like to see also coverage from this integration test module on business logic modules.
 
-To achieve this, we can use JaCoCo's [`report-aggregate`](https://www.jacoco.org/jacoco/trunk/doc/report-aggregate-mojo.html) goal, which will collect coverage information from all modules and create a single report with coverage for the whole project. 
+To achieve this, we can use JaCoCo's [`report-aggregate`](https://www.jacoco.org/jacoco/trunk/doc/report-aggregate-mojo.html) goal, which will collect coverage information from all modules and create a single report with coverage for the whole project.
 
 First, we still have to use `prepare-agent` goal as we did in basic example in all modules, the best way to achieve this is to configure the execution of this goal in the parent `pom.xml`. Then we need to add execution to the module containing integration tests to generate the report across modules
 
-```
+```xml
 <build>
   <plugins>
     <plugin>
@@ -92,15 +92,15 @@ First, we still have to use `prepare-agent` goal as we did in basic example in a
 
 We snippet binds the goal to the `verify` phase. Now when we execute
 
-```
+```shell
 mvn clean verify
 ```
 
 we should find the aggregated report in `target/site/jacoco-aggregate/jacoco.xml` of the module containing the integration tests.
 
-However, the JaCoCo plugin imports coverage reports module by module, so we need to import the same report multiple times (once for every module) to have coverage for all modules. To achieve this we set the property `sonar.coverage.jacoco.xmlReportPaths` in every module 
+However, the JaCoCo plugin imports coverage reports module by module, so we need to import the same report multiple times (once for every module) to have coverage for all modules. To achieve this we set the property `sonar.coverage.jacoco.xmlReportPaths` in every module
 
-```
+```xml
 <properties>
   <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../path_to_module_with_report/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 </properties>
@@ -110,25 +110,23 @@ However, the JaCoCo plugin imports coverage reports module by module, so we need
 
 To investigate issues with the import of coverage information you can run Maven with the debug flag, `-X`:
 
-```
+```shell
 mvn -X clean verify sonar:sonar 
 ```
 
 In the logs, you will find the execution of different sensors for each module of the project. Typically you will have a log similar to the following one when XML report is processed.
 
-```
+```shell
 [INFO] 16:58:05.074 Sensor JaCoCo XML Report Importer [jacoco]
 [DEBUG] 16:58:05.082 Reading report 'C:\projects\sonar-scanning-examples\maven-multimodule\tests\target\site\jacoco-aggregate\jacoco.xml'
 [INFO] 16:58:05.093 Sensor JaCoCo XML Report Importer [jacoco] (done) | time=19ms
 ```
 
-
-
 ## Gradle
 
 Gradle includes the [JaCoCo plugin](https://docs.gradle.org/current/userguide/jacoco_plugin.html) in its default distribution. To apply the plugin to a project, you need to declare it in your `build.gradle` file together with the [SonarScanner for Gradle](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-gradle/).
 
-```
+```plaintext
 plugins {
     id "jacoco"
     id "org.sonarqube" version "2.7.1"
@@ -137,7 +135,7 @@ plugins {
 
 The plugin provides the `jacocoTestReport` task, which needs to be configured to produce an XML report.
 
-```
+```xml
 jacocoTestReport {
     reports {
         xml.enabled true
@@ -147,11 +145,11 @@ jacocoTestReport {
 
 By default report will be saved under the `build/reports/jacoco` directory and this location will be picked up automatically by the `sonarqube` plugin, so there is no further configuration required. To import coverage, launch
 
-```
+```shell
 gradle build jacocoTestReport sonarqube
 ```
 
-It is convenient to execute the `jacocoTestReport` task every time we execute `test` with the JaCoCo agent; to achieve this, we can run it after the `test` task. We can use [`finalizedBy` ](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:finalizer_tasks) to create a dependency between `test` and `jacocoTestReport`. 
+It is convenient to execute the `jacocoTestReport` task every time we execute `test` with the JaCoCo agent; to achieve this, we can run it after the `test` task. We can use [`finalizedBy`](https://docs.gradle.org/current/userguide/more_about_tasks.html#sec:finalizer_tasks) to create a dependency between `test` and `jacocoTestReport`.
 
 ```groovy
 plugins.withType(JacocoPlugin) {

--- a/objc-llvm-coverage/README.md
+++ b/objc-llvm-coverage/README.md
@@ -1,15 +1,18 @@
+# Objective-C LLVM Coverage
+
 This example demonstrates how to analyze an Objective-C project with the SonarQube Scanner.
 
-Prerequisites
-=============
+## Prerequisites
+
 * [SonarQube](http://www.sonarqube.org/downloads/) 7.9+
 * [SonarQube Scanner](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) 4.5+
 * [SonarSource Objective-C Plugin](http://redirect.sonarsource.com/plugins/objectivec.html) 6.5+
 
-Usage
-=====
+## Usage
+
 * Build the project with SonarSource Build Wrapper:
 
+```shell
         mkdir DerivedData
 
         build-wrapper-macosx-x86 --out-dir DerivedData/compilation-database \
@@ -17,7 +20,10 @@ Usage
                 -scheme Example \
                 -derivedDataPath DerivedData \
                 clean test
+```
 
 * Analyze the project with SonarQube using the SonarQube Scanner:
 
+```shell
         sonar-scanner
+```

--- a/sonarqube-scanner-ant/README.md
+++ b/sonarqube-scanner-ant/README.md
@@ -1,15 +1,19 @@
-This example demonstrates how to analyze a simple project with Ant.
+# Sonarqube-Scanner Ant
 
-Prerequisites
-=============
+This example demonstrates how to analyze a simple project with Apache Ant.
+
+## Prerequisites
+
 * [SonarQube](http://www.sonarqube.org/downloads/) 7.9+
 * [SonarQube Scanner for Ant](http://redirect.sonarsource.com/doc/ant-task.html) 2.7+
 * [Ant](http://ant.apache.org/) 1.10.0 or higher
 
-Usage
-=====
+## Usage
+
 * Set the path to the SonarQube Ant Task in the build.xml file
 * Set the URL of your SonarQube instance in the property 'sonar.host.url'
 * Run the following command:
 
+```shell
         ant all
+```

--- a/sonarqube-scanner-build-wrapper-linux/README.md
+++ b/sonarqube-scanner-build-wrapper-linux/README.md
@@ -1,19 +1,25 @@
+# Sonarqube-Scanner BuildWrapper for Linux
+
 This example demonstrates how to use the BuildWrapper to analyze a C++ project with the SonarQube Scanner on Linux
 
-Prerequisites
-=============
+## Prerequisites
+
 * G++ compiler to compile the project sample
 * [SonarQube](http://www.sonarqube.org/downloads/) 7.9+
 * [SonarQube Scanner](https://redirect.sonarsource.com/doc/install-configure-scanner.html) 4.5+
 * [SonarCFamily for C/C++](https://www.sonarsource.com/why-us/products/codeanalyzers/sonarcfamilyforcpp.html)
 * [SonarSource Build Wrapper](https://docs.sonarqube.org/pages/viewpage.action?pageId=7996665)
 
-Usage
-=====
+## Usage
+
 * Run the build wrapper:
 
+```shell
         build-wrapper --out-dir bw-outputs ./build.sh
+```
 
 * Analyze the project with SonarQube using the SonarQube Scanner:
 
+```shell
         sonar-scanner
+```

--- a/sonarqube-scanner-gradle-multimodule/README.md
+++ b/sonarqube-scanner-gradle-multimodule/README.md
@@ -1,15 +1,24 @@
+# Sonarqube-Scanner for Multi-Module Java Gradle Project
+
 This example demonstrates how to analyze a multi-module Java project with Gradle.
 
-Prerequisites
-=============
+## Prerequisites
+
 * [SonarQube](http://www.sonarqube.org/downloads/) 7.9+
 * A gradle wrapper is included that bundles gradle. All other required plugins will be pulled by gradle as needed.
 
-Usage
-=====
+## Usage
+
 Run the following command (updating the sonar.host.url property as appropriate):
+
 * On Unix-like systems:
-  `./gradlew -Dsonar.host.url=http://myhost:9000 sonarqube`
+
+```shell
+  ./gradlew -Dsonar.host.url=http://myhost:9000 sonarqube
+```
+
 * On Windows:
-  `.\gradle.bat -Dsonar.host.url=http://myhost:9000 sonarqube`
-  
+
+```powershell
+  .\gradle.bat -Dsonar.host.url=http://myhost:9000 sonarqube
+```

--- a/sonarqube-scanner-gradle/README.md
+++ b/sonarqube-scanner-gradle/README.md
@@ -1,19 +1,21 @@
-This example demonstrates how to analyze a simple project built with gradle.
+# SonarQube Scanner for Gradle
 
-Prerequisites
-=============
+This example demonstrates how to analyze a simple project built with [Gradle](https://gradle.org/).
+
+## Prerequisites
+
 * [SonarQube](http://www.sonarqube.org/downloads/) 7.9+
 * A gradle wrapper is included that bundles gradle. All other required plugins will be pulled by gradle as needed.
 
-Usage
-=====
+## Usage
+
 Run the following command (updating the sonar.host.url property as appropriate):
+
 * On Unix-like systems:
   `./gradlew -Dsonar.host.url=http://myhost:9000 sonarqube`
 * On Windows:
   `.\gradle.bat -Dsonar.host.url=http://myhost:9000 sonarqube`
 
-Coverage
-=====
+## Coverage
+
 To get the project [test coverage](https://community.sonarsource.com/t/coverage-test-data-importing-jacoco-coverage-report-in-xml-format) computed, add gradle task `jacocoTestReport` to your command line.
-  

--- a/sonarqube-scanner-maven/maven-basic/README.md
+++ b/sonarqube-scanner-maven/maven-basic/README.md
@@ -2,13 +2,15 @@
 
 This simple Maven project is importing JaCoCo's coverage report. For multi-module project example 
 see [multi-module Maven project](../maven-multimodule/README.md)
-        
+
 ## Usage
 
 * Build the project, execute all the tests and analyze the project with SonarQube Scanner for Maven(from root  of the project):
 
+```shell
         mvn clean verify sonar:sonar
-        
+```
+
 ## Documentation
 
 [SonarScanner for Maven](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-maven/)

--- a/sonarqube-scanner-maven/maven-multimodule/README.md
+++ b/sonarqube-scanner-maven/maven-multimodule/README.md
@@ -1,22 +1,30 @@
 # Multi-module Apache Maven example
 
-This project imports JaCoCo's aggregate XML report to be able to report coverage across modules as well as unit
-test coverage inside the module. For a basic example see [basic maven project](../maven-basic/README.md).
+This project imports JaCoCo's aggregate XML report to be able to report coverage across modules as well as unit test coverage inside the module.
+
+For a basic example see [basic maven project](../maven-basic/README.md).
 
 ## Usage
 
 * Build the project, execute all the tests and analyze the project with SonarQube Scanner for Maven:
 
+```shell
         mvn clean verify sonar:sonar
+```
 
 ## Description
 
-This project consists of 3 modules. [`module1`](module1/pom.xml) and [`module2`](module2/pom.xml) contain "business logic" and 
-related unit tests. The [`tests`](tests/pom.xml) module contains integration tests which test functionality using both modules. 
-The `tests` module is also the one which creates the aggregate coverage report imported into SonarQube.
+This project consists of 3 modules.
 
-To generate the report we configure the JaCoCo plugin to attach its agent to the JVM which is executing the tests in the top 
-level [pom](pom.xml). This configuration is done in the `<pluginManagment>` section, so it will be applied on every submodule.
+* [`module1`](module1/pom.xml) and [`module2`](module2/pom.xml) contain "business logic" and related unit tests.
+
+* [`tests`](tests/pom.xml) module contains integration tests which test functionality using both modules.
+ `tests` module is also the one which creates the aggregate coverage report imported into SonarQube.
+
+To generate the report we configure the JaCoCo plugin to attach its agent to the JVM which is executing the tests in the top level [pom](pom.xml). 
+
+This configuration is done in the `<pluginManagment>` section, so it will be applied on every submodule.
+
 It is also configured inside the `coverage` profile, so this can be activated as needed (e.g. only in CI pipeline).
 
 ```xml
@@ -37,12 +45,15 @@ It is also configured inside the `coverage` profile, so this can be activated as
     </plugins>
   </pluginManagement>
 </build>
-```  
+```
 
-Once we have configured JaCoCo to collect coverage data, we need to generate the XML coverage report to be imported into 
-SonarQube. We will use [report-aggregate](https://www.jacoco.org/jacoco/trunk/doc/report-aggregate-mojo.html) goal which 
-collects data from all modules dependent on the `tests` module. To achieve this we configure the JaCoCo plugin by configuring execution 
- of `report-aggregate` goal in `verify` phase. See [pom.xml](tests/pom.xml) 
+Once we have configured JaCoCo to collect coverage data, we need to generate the XML coverage report to be imported into SonarQube.
+
+We will use [report-aggregate](https://www.jacoco.org/jacoco/trunk/doc/report-aggregate-mojo.html) goal which collects data from all modules dependent on the `tests` module.
+
+To achieve this we configure the JaCoCo plugin by configuring execution of `report-aggregate` goal in `verify` phase.
+
+See [pom.xml](tests/pom.xml)
 
 ```xml
 <build>
@@ -62,29 +73,27 @@ collects data from all modules dependent on the `tests` module. To achieve this 
     </plugin>
   </plugins>
 </build>
-``` 
+```
 
-This will create a report in `tests/target/site/jacoco-aggregate/jacoco.xml`. To import this report we will set 
+This will create a report in `tests/target/site/jacoco-aggregate/jacoco.xml`. To import this report we will set
 `sonar.coverage.jacoco.xmlReportPaths` property in every module on which this coverage should be imported
 
 ```xml
 <properties>
   <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
 </properties>
-``` 
+```
 
-We use `${aggregate.report.dir}` which is defined in the top level [`pom.xml`](pom.xml) to avoid duplicating the location of the 
-report in every module.
+We use `${aggregate.report.dir}` which is defined in the top level [`pom.xml`](pom.xml) to avoid duplicating the location of the report in every module.
 
 Alternately we can set this property on the command line with the `-D` switch:
 
-```
+```shell
 mvn -Dsonar.coverage.jacoco.xmlReportPaths=C:\projects\sonar-scanning-examples\sonarscanner-maven-aggregate\tests\target\site\jacoco-aggregate\jacoco.xml clean verify sonar:sonar 
 ```
 
 We have to use an absolute path, because the report will be imported for each module separately and the path is resolved relative to the module dir.
-    
-        
+
 ## Documentation
 
 [SonarScanner for Maven](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-maven/)

--- a/sonarqube-scanner-msbuild/CSharpProject/README.md
+++ b/sonarqube-scanner-msbuild/CSharpProject/README.md
@@ -1,22 +1,30 @@
+# SonarQube-Scanner MSBuild CSharp Project
+
 This example demonstrates how to analyze a .NET Solution with the SonarScanner for MSBuild.
 
-Prerequisites
-=============
+## Prerequisites
+
 * [SonarQube](http://www.sonarqube.org/downloads/) 7.9+ LTS
 * [SonarScanner for MSBuild](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner+for+MSBuild) 4.1.0+
 * [SonarSource C# Plugin](http://redirect.sonarsource.com/plugins/csharp.html) 7.15+
 * [Compatible .NET Build Environment](https://docs.sonarqube.org/latest/analysis/scan/sonarscanner-for-msbuild/)
 
-Usage
-=====
+## Usage
+
 * Run SonarScanner for MSBuild begin phase:
 
+```powershell
         SonarScanner.MSBuild.exe begin /k:"org.sonarqube:sonarqube-scanner-msbuild" /n:"Example of SonarScanner for MSBuild Usage" /v:"1.0"
+```
 
 * Build the project with MSBuild:
 
+```powershell
         MSBuild.exe /t:Rebuild
+```
 
 * Run SonarScanner for MSBuild end phase:
 
+```powershell
         SonarScanner.MSBuild.exe end
+```

--- a/sonarqube-scanner/README.md
+++ b/sonarqube-scanner/README.md
@@ -1,0 +1,3 @@
+# SonarQube-Scanner
+
+Example of SonarQube Scanner usage.

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -1,19 +1,22 @@
+# SonarQube-Scanner for Swift Code Coverage
+
 This example demonstrates how to import Xcode Coverage data (aka ProfData) to SonarQube for a Swift project.
 
-Prerequisites
-=============
+## Prerequisites
+
 * [SonarQube](http://www.sonarqube.org/downloads/) 6.7+
 * [SonarQube Scanner](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) 3.1+
 * [SonarSource Swift Plugin](http://redirect.sonarsource.com/plugins/swift.html) 3.2+
 
-Usage
-=====
+## Usage
 
 1. Run from "swift-coverage-example"
 
 1.a Build project
 
-`xcodebuild -project swift-coverage-example.xcodeproj/ -scheme swift-coverage-example -derivedDataPath Build/ -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO`
+```shell
+xcodebuild -project swift-coverage-example.xcodeproj/ -scheme swift-coverage-example -derivedDataPath Build/ -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
+```
 
 1.b Create code coverage report
 
@@ -33,4 +36,4 @@ XCode version | Command
 XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true`
 XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true`
 
-2. Verify that for the project "swift-coverage-example" the coverage value is 69.2%.
+2. Verify that for the project "swift-coverage-example" the coverage value is > 65%.


### PR DESCRIPTION
Fix style and spelling in the markdown documentation, minor formatting changes.  
Add fences around code.  Create a table of contents.

Also Fixes #81