### PR TITLE
Update xccov-to-sonarqube-generic.sh

### DIFF
--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -17,6 +17,11 @@ function convert_file {
 function xccov_to_generic {
   echo '<coverage version="1">'
   for xccovarchive_file in "$@"; do
+    if [[ ! -d $xccovarchive_file ]]
+    then
+      echo "Coverage FILE NOT FOUND AT PATH: $xccovarchive_file" 1>&2;
+      exit 1
+    fi
     local xccov_options=""
     if [[ $xccovarchive_file == *".xcresult"* ]]; then
       xccov_options="--archive"


### PR DESCRIPTION
The error output if a coverage file cannot be found is really unhelpful in its current form. It complains about the V1 API. This has been the cause of [many issues](https://community.sonarsource.com/t/sonarswift-code-coverage/17240). I believe this simple change to inform users of the script that it could not find the coverage file can really save some pain. I know it could've saved me several hours of work.