### PR TITLE
Manually set as main project as Product Project/Code

### DIFF
--- a/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplication/SomeConsoleApplication.csproj
+++ b/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplication/SomeConsoleApplication.csproj
@@ -13,6 +13,10 @@
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
   </PropertyGroup>
+  <PropertyGroup>
+    <!-- Project is not a test project -->
+    <SonarQubeTestProject>false</SonarQubeTestProject>
+  </PropertyGroup> 
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Without setting it manually or removing reference to 'Microsoft.VisualStudio.TestPlatform.TestFramework', then the sonar-scanner-msbuild will categorize this project as TEST code/project. See [categorization logic](https://github.com/SonarSource/sonar-scanner-msbuild/wiki/Analysis-of-product-projects-vs.-test-projects). This is what you will see if you don't manually set as Product/Main Project:
```text
SonarCategoriseProject:
  Sonar: (SomeConsoleApplication.csproj) Categorizing project as test or product code...
  Sonar: (SomeConsoleApplication.csproj) project is evaluated as a test project based on the 'Microsoft.VisualStudio.TestPlatform.TestFramework' reference.
  Sonar: (SomeConsoleApplication.csproj) categorized as TEST project (test code).
```

After:
```text
SonarCategoriseProject:
  Sonar: (SomeConsoleApplication.csproj) Categorizing project as test or product code...
  Sonar: (SomeConsoleApplication.csproj) SonarQubeTestProject has been set explicitly to false.
  Sonar: (SomeConsoleApplication.csproj) categorized as MAIN project (production code).
```