### PR TITLE
aggregate execution data only if jacoco extension is enabled

### DIFF
--- a/sonarqube-scanner-gradle/gradle-multimodule-coverage/build.gradle
+++ b/sonarqube-scanner-gradle/gradle-multimodule-coverage/build.gradle
@@ -45,6 +45,8 @@ tasks.register("codeCoverageReport", JacocoReport) {
                 if (testTask.extensions.getByType(JacocoTaskExtension).isEnabled()) {
                     sourceSets subproject.sourceSets.main
                     executionData(testTask)
+                }else{
+                    logger.warn('Jacoco extension is disabled for test task \'{}\' in project \'{}\'. this test task will be excluded from jacoco report.',testTask.getName(),subproject.getName())
                 }
             }
 

--- a/sonarqube-scanner-gradle/gradle-multimodule-coverage/build.gradle
+++ b/sonarqube-scanner-gradle/gradle-multimodule-coverage/build.gradle
@@ -41,8 +41,11 @@ tasks.register("codeCoverageReport", JacocoReport) {
     subprojects { subproject ->
         subproject.plugins.withType(JacocoPlugin).configureEach {
             subproject.tasks.matching({ t -> t.extensions.findByType(JacocoTaskExtension) }).configureEach { testTask ->
-                sourceSets subproject.sourceSets.main
-                executionData(testTask)
+                //the jacoco extension may be disabled for some projects
+                if (testTask.extensions.getByType(JacocoTaskExtension).isEnabled()) {
+                    sourceSets subproject.sourceSets.main
+                    executionData(testTask)
+                }
             }
 
             // To automatically run `test` every time `./gradlew codeCoverageReport` is called,


### PR DESCRIPTION
the jacoco extension may be disabled for some projects so aggregate execution data only if its enabled.