### PR TITLE
update maven multimodule example to use multiModuleProjectDirectory

### DIFF
--- a/sonarqube-scanner-maven/maven-multimodule/README.md
+++ b/sonarqube-scanner-maven/maven-multimodule/README.md
@@ -76,15 +76,13 @@ See [pom.xml](tests/pom.xml)
 ```
 
 This will create a report in `tests/target/site/jacoco-aggregate/jacoco.xml`. To import this report we will set
-`sonar.coverage.jacoco.xmlReportPaths` property in every module on which this coverage should be imported
+`sonar.coverage.jacoco.xmlReportPaths` property with the `${maven.multiModuleProjectDirectory}` so every module knows where the coverage should be imported from
 
 ```xml
 <properties>
-  <sonar.coverage.jacoco.xmlReportPaths>${project.basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
+  <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
 </properties>
 ```
-
-We use `${aggregate.report.dir}` which is defined in the top level [`pom.xml`](pom.xml) to avoid duplicating the location of the report in every module.
 
 Alternately we can set this property on the command line with the `-D` switch:
 

--- a/sonarqube-scanner-maven/maven-multimodule/module1/pom.xml
+++ b/sonarqube-scanner-maven/maven-multimodule/module1/pom.xml
@@ -13,9 +13,4 @@
 
   <name>Module 1</name>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
-  </properties>
-
-
 </project>

--- a/sonarqube-scanner-maven/maven-multimodule/module2/pom.xml
+++ b/sonarqube-scanner-maven/maven-multimodule/module2/pom.xml
@@ -13,9 +13,4 @@
 
   <name>Module 2</name>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
-  </properties>
-
-
 </project>

--- a/sonarqube-scanner-maven/maven-multimodule/pom.xml
+++ b/sonarqube-scanner-maven/maven-multimodule/pom.xml
@@ -21,7 +21,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <aggregate.report.dir>tests/target/site/jacoco-aggregate/jacoco.xml</aggregate.report.dir>
+    <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
   </properties>
 
   <dependencies>

--- a/sonarqube-scanner-maven/maven-multimodule/tests/pom.xml
+++ b/sonarqube-scanner-maven/maven-multimodule/tests/pom.xml
@@ -11,10 +11,6 @@
 
   <artifactId>tests</artifactId>
 
-  <properties>
-    <sonar.coverage.jacoco.xmlReportPaths>${basedir}/../${aggregate.report.dir}</sonar.coverage.jacoco.xmlReportPaths>
-  </properties>
-
   <name>Tests</name>
 
   <dependencies>


### PR DESCRIPTION
- Removed `sonar.coverage.jacoco.xmlReportPaths` properties from `module1`, `module2` and `tests`
- Set `sonar.coverage.jacoco.xmlReportPaths` in `sonarscanner-maven-aggregate` module using `${maven.multiModuleProjectDirectory`
- Updated README.md to reflect property usage