### PR TITLE
Update swift example

### DIFF
--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -27,13 +27,13 @@ XCode version | Command
 XCode 8+ - 9.2 | `xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
 XCode 9.3 - 9.4.1 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
 XCode 10 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/*_Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
-XCode 11 & 12 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml` <br> **Requires [jq](https://stedolan.github.io/jq/), remove the optimize_format function use if you can't use it)**
+XCode 11 & 12 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml` <br> **Requires [jq](https://stedolan.github.io/jq/) (remove the optimize_format function use if you can't use it)**
 
 1.c Import code coverage report
 
 XCode version | Command
 --- | ---
-XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report -Dsonar.cfamily.build-wrapper-output.bypass=true`
-XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml -Dsonar.cfamily.build-wrapper-output.bypass=true`
+XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report`
+XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml`
 
 2. Verify that for the project "swift-coverage-example" the coverage value is > 65%.

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -33,7 +33,7 @@ XCode 11 & 12 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ 
 
 XCode version | Command
 --- | ---
-XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPath=Coverage.report`
+XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPaths=Coverage.report`
 XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml`
 
 2. Verify that for the project "swift-coverage-example" the coverage value is > 65%.

--- a/swift-coverage/swift-coverage-example/sonar-project.properties
+++ b/swift-coverage/swift-coverage-example/sonar-project.properties
@@ -5,4 +5,4 @@ sonar.projectVersion=1.0
 sonar.sources=swift-coverage-example
 
 sonar.coverageReportPaths=sonarqube-generic-coverage.xml
-#sonar.swift.coverage.reportPath=Coverage.report
+#sonar.swift.coverage.reportPaths=Coverage.report

--- a/swift-coverage/swift-coverage-example/sonar-project.properties
+++ b/swift-coverage/swift-coverage-example/sonar-project.properties
@@ -2,7 +2,7 @@ sonar.projectKey=swift-coverage-example
 sonar.projectName=swift-coverage-example
 sonar.projectVersion=1.0
 
-sonar.swift.coverage.reportPath=Coverage.report
 sonar.sources=swift-coverage-example
 
-#sonar.coverageReportPaths=sonarqube-generic-coverage.xml
+sonar.coverageReportPaths=sonarqube-generic-coverage.xml
+#sonar.swift.coverage.reportPath=Coverage.report

--- a/swift-coverage/swift-coverage-example/sonar-project.properties
+++ b/swift-coverage/swift-coverage-example/sonar-project.properties
@@ -3,6 +3,3 @@ sonar.projectName=swift-coverage-example
 sonar.projectVersion=1.0
 
 sonar.sources=swift-coverage-example
-
-sonar.coverageReportPaths=sonarqube-generic-coverage.xml
-#sonar.swift.coverage.reportPaths=Coverage.report


### PR DESCRIPTION
The property `sonar.cfamily.build-wrapper-output.bypass` has been deprecated for a few years now and is not needed.
I have also updated the `sonar-project.properties` so that it does not use a deprecated property `(sonar.swift.coverage.reportPath)` by default.