### PR TITLE
Faster xccov to sonarqube generic

### DIFF
--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -27,7 +27,7 @@ XCode version | Command
 XCode 8+ - 9.2 | `xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
 XCode 9.3 - 9.4.1 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
 XCode 10 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/*_Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
-XCode 11 & 12 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml` <br> **Requires [jq](https://stedolan.github.io/jq/) (remove the optimize_format function use if you can't use it)**
+XCode 11+ | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml`
 
 1.c Import code coverage report
 

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -1,7 +1,7 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-if [[ $# -ne 1 ]]; then
+if [[ $# -lt 1 ]]; then
 	echo -e "Export coverage from Xcode xcresult or xccovarchive in Sonarcube Generic Test Data format\n"
     echo "Usage: $(basename $0) <xcresult/xccovarchive> [<xcresult/xccovarchive> ...]" >&2
     exit 2

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -1,89 +1,44 @@
 #!/usr/bin/env bash
 set -euo pipefail
 
-function convert_file {
-  local xccovarchive_file="$1"
-  local file_name="$2"
-  local xccov_options="$3"
-  echo "  <file path=\"$file_name\">"
-  xcrun xccov view $xccov_options --file "$file_name" "$xccovarchive_file" | \
-    sed -n '
-    s/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p;
-    s/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p
-    '
-  echo '  </file>'
-}
+if [[ $# -ne 1 ]]; then
+	echo -e "Export coverage from Xcode xcresult or xccovarchive in Sonarcube Generic Test Data format\n"
+    echo "Usage: $(basename $0) <xcresult/xccovarchive> [<xcresult/xccovarchive> ...]" >&2
+    exit 2
+fi
 
-function xccov_to_generic {
-  echo '<coverage version="1">'
-  for xccovarchive_file in "$@"; do
-    if [[ ! -d $xccovarchive_file ]]
-    then
+
+for xccovarchive_file in "$@"; do
+	if [[ ! -d $xccovarchive_file ]]; then
       echo "Coverage FILE NOT FOUND AT PATH: $xccovarchive_file" 1>&2;
       exit 1
     fi
 
-    if [ $xcode_version -gt 10 ]; then # Apply optimization
-       xccovarchive_file=$(optimize_format)
-    fi
-
-    local xccov_options=""
+    xccov_options=""
     if [[ $xccovarchive_file == *".xcresult"* ]]; then
       xccov_options="--archive"
     fi
-    xcrun xccov view $xccov_options --file-list "$xccovarchive_file" | while read -r file_name; do
-      convert_file "$xccovarchive_file" "$file_name" "$xccov_options"
-    done
-  done
-  echo '</coverage>'
-}
-
-function check_xcode_version {
-  xcode_major_version=`xcodebuild -version | head -n 1 | cut -d " " -f2 | cut -d . -f1`
-
-  if [ $? -ne 0 ]; then 
-    echo 'Failed to execute xcrun show-sdk-version' 1>&2
-    exit -1
-  fi
-  echo $xcode_major_version
-}
-
-function cleanup_tmp_files {
-  rm -rf tmp.json
-  rm -rf tmp.xccovarchive
-}
-
-# Optimize coverage files conversion time by exporting to a clean xcodearchive directory
-# Credits to silverhammermba on issue #68 for the suggestion
-function optimize_format {
-  cleanup_tmp_files
-  xcrun xcresulttool get --format json --path "$xccovarchive_file" > tmp.json
-  if [ $? -ne 0 ]; then 
-    echo 'Failed to execute xcrun xcresulttool get' 1>&2
-    exit -1
-  fi
-
-  # local reference=$(jq -r '.actions._values[2].actionResult.coverage.archiveRef.id._value'  tmp.json)
-  local reference=$(jq -r '.actions._values[]|[.actionResult.coverage.archiveRef.id],._values'  tmp.json | grep value | cut -d : -f 2 | cut -d \" -f 2)
-  if [ $? -ne 0 ]; then 
-    echo 'Failed to execute jq (https://stedolan.github.io/jq/)' 1>&2
-    exit -1
-  fi
-  # $reference can be a list of IDs (from a merged .xcresult bundle of multiple test plans)
-  for test_ref in $reference; do
-    xcrun xcresulttool export --type directory --path "$xccovarchive_file" --id "$test_ref" --output-path tmp.xccovarchive
-    if [ $? -ne 0 ]; then 
-      echo "Failed to execute xcrun xcresulttool export for reference ${test_ref}" 1>&2
-      exit -1
-    fi
-  done
-  echo "tmp.xccovarchive"
-}
-
-xcode_version=$(check_xcode_version)
-if [ $? -ne 0 ]; then
-  exit -1
-fi
-
-xccov_to_generic "$@"
-cleanup_tmp_files
+ 
+	xcrun xccov view $xccov_options "$xccovarchive_file" | 
+		awk '
+			BEGIN {
+				FS=":"
+				print "<coverage version=\"1\">"
+			}
+			/^\//{
+				if (file) print "  </file>"
+				print "  <file path=\""$1"\">"
+				file=1
+			}
+			/^ *[0-9]*: [0-9]+( \[)?/{
+				gsub(/ +/,"",$1)
+				gsub(/ +/,"",$2);gsub(/\[/,"",$2)
+				if(int($2)>0) covered="true"; else covered="false"
+				print "    <lineToCover lineNumber=\""$1"\" covered=\""covered"\"\/>"
+			}
+			END {
+				if(file)print "  </file>"
+				print "</coverage>"
+			}
+		'
+done


### PR DESCRIPTION
This is a rewrite of `xccov-to-sonarqube-generic.sh` using just `xccov` and `awk` - and it's a lot faster.

It makes a significant difference for medium and large projects. In my case, the runtime on an M1 pro is reduced from about 1 minute 52 seconds to a tiny instant.