### PR TITLE
Bump SomeConsoleApplication version to .NET Framework 4.8

### DIFF
--- a/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplication/App.config
+++ b/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplication/App.config
@@ -1,6 +1,6 @@
-﻿<?xml version="1.0" encoding="utf-8" ?>
+<?xml version="1.0" encoding="utf-8"?>
 <configuration>
     <startup> 
-        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.5.2" />
+        <supportedRuntime version="v4.0" sku=".NETFramework,Version=v4.8"/>
     </startup>
 </configuration>

--- a/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplication/SomeConsoleApplication.csproj
+++ b/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplication/SomeConsoleApplication.csproj
@@ -9,14 +9,15 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SomeConsoleApplication</RootNamespace>
     <AssemblyName>SomeConsoleApplication</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup>
     <!-- Project is not a test project -->
     <SonarQubeTestProject>false</SonarQubeTestProject>
-  </PropertyGroup> 
+  </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <PlatformTarget>AnyCPU</PlatformTarget>
     <DebugSymbols>true</DebugSymbols>

--- a/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplicationTest/SomeConsoleApplicationTest.csproj
+++ b/sonarqube-scanner-msbuild/CSharpProject/SomeConsoleApplicationTest/SomeConsoleApplicationTest.csproj
@@ -8,7 +8,7 @@
     <AppDesignerFolder>Properties</AppDesignerFolder>
     <RootNamespace>SomeConsoleApplicationTest</RootNamespace>
     <AssemblyName>SomeConsoleApplicationTest</AssemblyName>
-    <TargetFrameworkVersion>v4.5.2</TargetFrameworkVersion>
+    <TargetFrameworkVersion>v4.8</TargetFrameworkVersion>
     <FileAlignment>512</FileAlignment>
     <ProjectTypeGuids>{3AC096D0-A1C2-E12C-1390-A8335801FDAB};{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}</ProjectTypeGuids>
     <VisualStudioVersion Condition="'$(VisualStudioVersion)' == ''">10.0</VisualStudioVersion>
@@ -16,6 +16,7 @@
     <ReferencePath>$(ProgramFiles)\Common Files\microsoft shared\VSTT\$(VisualStudioVersion)\UITestExtensionPackages</ReferencePath>
     <IsCodedUITest>False</IsCodedUITest>
     <TestProjectType>UnitTest</TestProjectType>
+    <TargetFrameworkProfile />
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|AnyCPU' ">
     <DebugSymbols>true</DebugSymbols>


### PR DESCRIPTION
Hello, 

I did try to scan the CSharpProject and realized that it was using .NET Framework 4.5.2., which is [not supported anymore](https://dotnet.microsoft.com/en-us/download/dotnet-framework/net452). 

I suggest upgrading to .NET Framework 4.8, which doesn't seem to introduce any regressions. 

I was able to build the software after this upgrade and run a scanner. 

Note that the suggested changes were made by Visual Studio, which suggested these changes.

 