### PR TITLE
Update swift coverage conversion script for Xcode 13 and 14

### DIFF
--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -1,11 +1,11 @@
 # SonarQube-Scanner for Swift Code Coverage
 
-This example demonstrates how to import Xcode Coverage data (aka ProfData) to SonarQube for a Swift project.
+This example demonstrates how to import Xcode Coverage data (aka ProfData) to SonarQube for a Swift project. It supports Xcode 13 and above.
 
 ## Prerequisites
 
-* [SonarQube](http://www.sonarqube.org/downloads/) 8.9 LTS or Latest
-* [SonarQube Scanner](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) 4.7+
+* [SonarQube](http://www.sonarqube.org/downloads/) 9.8 or Latest
+* [SonarQube Scanner](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) 4.8+
 
 ## Usage
 
@@ -17,22 +17,35 @@ This example demonstrates how to import Xcode Coverage data (aka ProfData) to So
 xcodebuild -project swift-coverage-example.xcodeproj/ -scheme swift-coverage-example -derivedDataPath Build/ -enableCodeCoverage YES clean build test CODE_SIGN_IDENTITY="" CODE_SIGNING_REQUIRED=NO
 ```
 
-1.b Create code coverage report
+1.b Using xccov (recommended)
 
-**Note** : The <device_id> used in the below command can be found from the XCode tools command: `instruments -s devices`
+Create code coverage report
 
-XCode version | Command
---- | ---
-XCode 8+ - 9.2 | `xcrun llvm-cov show -instr-profile=Build/ProfileData/<device_id>/Coverage.profdata Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example > Coverage.report`
-XCode 9.3 - 9.4.1 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
-XCode 10 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/*_Test/*.xccovarchive/ > sonarqube-generic-coverage.xml`
-XCode 11 & 12 | `bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ > sonarqube-generic-coverage.xml` <br> **Requires [jq](https://stedolan.github.io/jq/) (remove the optimize_format function use if you can't use it)**
+```shell
+bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ >Coverage.xml
+```
 
-1.c Import code coverage report
+Import code coverage report
 
-XCode version | Command
---- | ---
-XCode 8.x - 9.2 | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPaths=Coverage.report`
-XCode 9.3+ | `sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=sonarqube-generic-coverage.xml`
+```shell
+sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=Coverage.xml
+```
+
+1.b Using llvm-cov 
+
+Create code coverage report
+
+```shell
+xcrun --run llvm-cov show -instr-profile=Build/Build/ProfileData/<id>/Coverage.profdata \
+      Build/Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example \
+      -object ./Build/Build/Products/Debug/swift-coverage-example.app/Contents/PlugIns/swift-coverage-exampleTests.xctest/Contents/MacOS/swift-coverage-exampleTests \
+      >Coverage.report
+```
+
+Import code coverage report
+
+```shell
+sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPaths=Coverage.report
+```
 
 2. Verify that for the project "swift-coverage-example" the coverage value is > 65%.

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -1,11 +1,12 @@
 # SonarQube-Scanner for Swift Code Coverage
 
-This example demonstrates how to import Xcode Coverage data to SonarQube for a Swift project. It supports Xcode 13 and above.
+This example demonstrates how to import Xcode Coverage data to SonarQube for a Swift project.
 
 ## Prerequisites
 
-* [SonarQube](http://www.sonarqube.org/downloads/) 8.9 LTS or Latest
-* [SonarQube Scanner](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) 4.7+
+* [SonarQube](https://www.sonarsource.com/products/sonarqube/downloads/) 8.9 LTS or Latest
+* [SonarQube Scanner](https://docs.sonarqube.org/latest/analyzing-source-code/scanners/sonarscanner/) 4.7+
+* [Xcode](https://developer.apple.com/xcode/) 13.3+
 
 ## Usage
 
@@ -24,11 +25,10 @@ data and is more straightforward to use than the older `llvm-cov` tool. With
 the script `xccov-to-sonarqube-generic.sh`, you can convert Xcode test results
 stored in `*.xcresult` folders to the [SonarQube generic test coverage format](https://docs.sonarqube.org/latest/analyzing-source-code/test-coverage/generic-test-data/).
 
-First, locate the Xcode test result folder and convert the coverage data to the
-SonarQube format using the script as in the following example:
+First, locate the Xcode test result folder (`*.xcresult`). Then use it as a parameter to the script converting the coverage data to the SonarQube format as in the following example:
 
 ```shell
-bash xccov-to-sonarqube-generic.sh Build/Logs/Test/Run-swift-coverage-example-2023.01.27_16-07-44-+0100.xcresult >Coverage.xml
+bash xccov-to-sonarqube-generic.sh Build/Logs/Test/Run-swift-coverage-example-2023.01.27_16-07-44-+0100.xcresult/ >Coverage.xml
 ```
 
 Then, use the parameter `sonar.coverageReportPaths` to reference the generated report:
@@ -47,7 +47,7 @@ coverage for the application executable and the dynamic library binaries.
 
 In the case of the project example, first, locate the `Coverage.profdata` file
 under the `ProfileData` folder. Then, generate an `llvm-cov` report as in the
-following example:
+following example (the located `Coverage.profdata` file should be the value of `-instr-profile` parameter):
 
 ```shell
 xcrun --run llvm-cov show -instr-profile=Build/Build/ProfileData/00006000-000428843C29801E/Coverage.profdata \

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -19,30 +19,42 @@ xcodebuild -project swift-coverage-example.xcodeproj/ -scheme swift-coverage-exa
 
 1.b Using xccov (recommended)
 
-Create code coverage report
+The `xccov` command line tool is the recommended option to view Xcode coverage
+data and is more straightforward to use than the older `llvm-cov` tool. With
+the script `xccov-to-sonarqube-generic.sh`, you can convert Xcode test results
+stored in `*.xcresult` folders to a SonarQube generic XML file and then pass it
+to the Sonar Scanner to get your Xcode coverage data into SonarQube.
+
+First, convert your Xcode coverage to the SonarQube generic format with the
+command:
 
 ```shell
 bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ >Coverage.xml
 ```
 
-Import code coverage report
+Then, configure the report file with the `sonar.coverageReportPaths` option
+when executing sonar-scanner:
 
 ```shell
-sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.coverageReportPaths=Coverage.xml
+sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.coverageReportPaths=Coverage.xml
 ```
 
 1.b Using llvm-cov 
 
-Create code coverage report
+You can also provide code coverage data using the `llvm-cov` format. The
+process of generating an llvm-cov report requires several steps to get the
+coverage for the application executable and the dynamic library binaries. For
+the project example, you can use the following command where `<id>` should
+match the folder name under `ProfileData`:
 
 ```shell
 xcrun --run llvm-cov show -instr-profile=Build/Build/ProfileData/<id>/Coverage.profdata \
       Build/Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example \
-      -object ./Build/Build/Products/Debug/swift-coverage-example.app/Contents/PlugIns/swift-coverage-exampleTests.xctest/Contents/MacOS/swift-coverage-exampleTests \
       >Coverage.report
 ```
 
-Import code coverage report
+Then, configure the report file with the `sonar.swift.coverage.reportPaths`
+option when executing sonar-scanner:
 
 ```shell
 sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPaths=Coverage.report

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -1,11 +1,11 @@
 # SonarQube-Scanner for Swift Code Coverage
 
-This example demonstrates how to import Xcode Coverage data (aka ProfData) to SonarQube for a Swift project. It supports Xcode 13 and above.
+This example demonstrates how to import Xcode Coverage data to SonarQube for a Swift project. It supports Xcode 13 and above.
 
 ## Prerequisites
 
-* [SonarQube](http://www.sonarqube.org/downloads/) 9.8 or Latest
-* [SonarQube Scanner](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) 4.8+
+* [SonarQube](http://www.sonarqube.org/downloads/) 8.9 LTS or Latest
+* [SonarQube Scanner](http://docs.sonarqube.org/display/SCAN/Analyzing+with+SonarQube+Scanner) 4.7+
 
 ## Usage
 
@@ -22,42 +22,41 @@ xcodebuild -project swift-coverage-example.xcodeproj/ -scheme swift-coverage-exa
 The `xccov` command line tool is the recommended option to view Xcode coverage
 data and is more straightforward to use than the older `llvm-cov` tool. With
 the script `xccov-to-sonarqube-generic.sh`, you can convert Xcode test results
-stored in `*.xcresult` folders to a SonarQube generic XML file and then pass it
-to the Sonar Scanner to get your Xcode coverage data into SonarQube.
+stored in `*.xcresult` folders to the [SonarQube generic test coverage format](https://docs.sonarqube.org/latest/analyzing-source-code/test-coverage/generic-test-data/).
 
-First, convert your Xcode coverage to the SonarQube generic format with the
+First, convert your Xcode coverage to the SonarQube format with the
 command:
 
 ```shell
 bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ >Coverage.xml
 ```
 
-Then, configure the report file with the `sonar.coverageReportPaths` option
-when executing sonar-scanner:
+Then, use the parameter `sonar.coverageReportPaths` to reference the generated report:
 
 ```shell
-sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.coverageReportPaths=Coverage.xml
+sonar-scanner -Dsonar.coverageReportPaths=Coverage.xml
 ```
+
+This parameter accepts a comma-separated list of files, which means you can also provide multiple coverage reports from multiple test results.
 
 1.b Using llvm-cov 
 
 You can also provide code coverage data using the `llvm-cov` format. The
 process of generating an llvm-cov report requires several steps to get the
-coverage for the application executable and the dynamic library binaries. For
-the project example, you can use the following command where `<id>` should
-match the folder name under `ProfileData`:
+coverage for the application executable and the dynamic library binaries.
+
+In the case of the project example, first, locate the `Coverage.profdata` file under the `ProfileData` folder. Then, generate an `llvm-cov` report with the command:
 
 ```shell
-xcrun --run llvm-cov show -instr-profile=Build/Build/ProfileData/<id>/Coverage.profdata \
+xcrun --run llvm-cov show -instr-profile=Build/Build/ProfileData/xxxx/Coverage.profdata \
       Build/Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example \
       >Coverage.report
 ```
 
-Then, configure the report file with the `sonar.swift.coverage.reportPaths`
-option when executing sonar-scanner:
+Finally, use the parameter `sonar.swift.coverage.reportPaths` to reference the generated report. This parameter also accepts a comma-separated list of files.
 
 ```shell
-sonar-scanner -Dsonar.projectKey=TestCoverage -Dsonar.sources=. -Dsonar.swift.coverage.reportPaths=Coverage.report
+sonar-scanner -Dsonar.swift.coverage.reportPaths=Coverage.report
 ```
 
-2. Verify that for the project "swift-coverage-example" the coverage value is > 65%.
+2. Verify that for the project "swift-coverage-example" the coverage value is around 75%.

--- a/swift-coverage/README.md
+++ b/swift-coverage/README.md
@@ -24,11 +24,11 @@ data and is more straightforward to use than the older `llvm-cov` tool. With
 the script `xccov-to-sonarqube-generic.sh`, you can convert Xcode test results
 stored in `*.xcresult` folders to the [SonarQube generic test coverage format](https://docs.sonarqube.org/latest/analyzing-source-code/test-coverage/generic-test-data/).
 
-First, convert your Xcode coverage to the SonarQube format with the
-command:
+First, locate the Xcode test result folder and convert the coverage data to the
+SonarQube format using the script as in the following example:
 
 ```shell
-bash xccov-to-sonarqube-generic.sh Build/Logs/Test/*.xcresult/ >Coverage.xml
+bash xccov-to-sonarqube-generic.sh Build/Logs/Test/Run-swift-coverage-example-2023.01.27_16-07-44-+0100.xcresult >Coverage.xml
 ```
 
 Then, use the parameter `sonar.coverageReportPaths` to reference the generated report:
@@ -45,10 +45,12 @@ You can also provide code coverage data using the `llvm-cov` format. The
 process of generating an llvm-cov report requires several steps to get the
 coverage for the application executable and the dynamic library binaries.
 
-In the case of the project example, first, locate the `Coverage.profdata` file under the `ProfileData` folder. Then, generate an `llvm-cov` report with the command:
+In the case of the project example, first, locate the `Coverage.profdata` file
+under the `ProfileData` folder. Then, generate an `llvm-cov` report as in the
+following example:
 
 ```shell
-xcrun --run llvm-cov show -instr-profile=Build/Build/ProfileData/xxxx/Coverage.profdata \
+xcrun --run llvm-cov show -instr-profile=Build/Build/ProfileData/00006000-000428843C29801E/Coverage.profdata \
       Build/Build/Products/Debug/swift-coverage-example.app/Contents/MacOS/swift-coverage-example \
       >Coverage.report
 ```

--- a/swift-coverage/swift-coverage-example/.gitignore
+++ b/swift-coverage/swift-coverage-example/.gitignore
@@ -3,4 +3,5 @@ Index/
 Logs/
 Build/
 .scannerwork
-sonarqube-generic-coverage.xml
+Coverage.xml
+Coverage.report

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -2,34 +2,18 @@
 set -euo pipefail
 
 function convert_xccov_to_xml {
-    sed -n                                                                                       \
-        -e '/:$/s/&/\&amp;/g;s/^\(.*\):$/  <file path="\1">/p'                                   \
-        -e 's/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p'    \
-        -e 's/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p' \
-        -e 's/^$/  <\/file>/p'
-}
-
-function convert_archive {
-  local xccovarchive_file="$1"
-  xcrun xccov view --archive "$xccovarchive_file" | convert_xccov_to_xml
+  sed -n                                                                                       \
+      -e '/:$/s/&/\&amp;/g;s/^\(.*\):$/  <file path="\1">/p'                                   \
+      -e 's/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p'    \
+      -e 's/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p' \
+      -e 's/^$/  <\/file>/p'
 }
 
 function xccov_to_generic {
-  echo '<coverage version="1">'
-  for xccovarchive_file in "$@"; do
-    if [[ ! -d $xccovarchive_file ]]; then
-      echo "Coverage file not found at path: $xccovarchive_file" 1>&2;
-      exit 1
-    elif (( xcode_version < 13 )); then
-      echo "Xcode version not supported ($xcode_version) version 13 or above is required" 1>&2;
-      exit 1
-    elif [[ $xccovarchive_file != *".xcresult"* ]]; then
-      echo "Incorrect test results path. Required *.xcresult: $xccovarchive_file" 1>&2;
-      exit 1
-    fi
+  local xcresult="$1"
 
-    convert_archive "$xccovarchive_file"
-  done
+  echo '<coverage version="1">'
+  xcrun xccov view --archive "$xcresult" | convert_xccov_to_xml
   echo '</coverage>'
 }
 
@@ -48,4 +32,17 @@ if [ $? -ne 0 ]; then
   exit -1
 fi
 
-xccov_to_generic "$@"
+xcresult="$1"
+
+if (( xcode_version < 13 )); then
+  echo "Xcode version not supported ($xcode_version) version 13 or above is required" 1>&2;
+  exit 1
+elif [[ ! -d $xcresult ]]; then
+  echo "Coverage file not found at path: $xcresult" 1>&2;
+  exit 1
+elif [[ $xcresult != *".xcresult"* ]]; then
+  echo "Expecting input to match '*.xcresult', got: $xcresult" 1>&2;
+  exit 1
+fi
+
+xccov_to_generic "$xcresult"

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -26,7 +26,7 @@ if ! xcode_version="$(xcodebuild -version | sed -n '1s/^Xcode \([0-9.]*\)$/\1/p'
   echo 'Failed to get Xcode version' 1>&2
   exit 1
 elif check_xcode_version ${xcode_version//./ }; then
-  echo "Xcode version '$xcode_version' not supported version 13.3 or above is required" 1>&2;
+  echo "Xcode version '$xcode_version' not supported, version 13.3 or above is required" 1>&2;
   exit 1
 fi
 

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -36,7 +36,7 @@ function xccov_to_generic {
       exit 1
     fi
 
-    if (( xcode_version >= 14 )) && [[ $xccovarchive_file == *".xcresult"* ]]; then
+    if (( xcode_version >= 13 )) && [[ $xccovarchive_file == *".xcresult"* ]]; then
       convert_archive "$xccovarchive_file"
       continue
     fi

--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -14,44 +14,21 @@ function convert_archive {
   xcrun xccov view --archive "$xccovarchive_file" | convert_xccov_to_xml
 }
 
-function convert_file {
-  local xccovarchive_file="$1"
-  local file_name="$2"
-  local xccov_options="$3"
-  echo "  <file path=\"$file_name\">"
-  xcrun xccov view $xccov_options --file "$file_name" "$xccovarchive_file" | \
-    sed -n '
-    s/^ *\([0-9][0-9]*\): 0.*$/    <lineToCover lineNumber="\1" covered="false"\/>/p;
-    s/^ *\([0-9][0-9]*\): [1-9].*$/    <lineToCover lineNumber="\1" covered="true"\/>/p
-    '
-  echo '  </file>'
-}
-
 function xccov_to_generic {
   echo '<coverage version="1">'
   for xccovarchive_file in "$@"; do
-    if [[ ! -d $xccovarchive_file ]]
-    then
-      echo "Coverage FILE NOT FOUND AT PATH: $xccovarchive_file" 1>&2;
+    if [[ ! -d $xccovarchive_file ]]; then
+      echo "Coverage file not found at path: $xccovarchive_file" 1>&2;
+      exit 1
+    elif (( xcode_version < 13 )); then
+      echo "Xcode version not supported ($xcode_version) version 13 or above is required" 1>&2;
+      exit 1
+    elif [[ $xccovarchive_file != *".xcresult"* ]]; then
+      echo "Incorrect test results path. Required *.xcresult: $xccovarchive_file" 1>&2;
       exit 1
     fi
 
-    if (( xcode_version >= 13 )) && [[ $xccovarchive_file == *".xcresult"* ]]; then
-      convert_archive "$xccovarchive_file"
-      continue
-    fi
-
-    if [ $xcode_version -gt 10 ]; then # Apply optimization
-       xccovarchive_file=$(optimize_format)
-    fi
-
-    local xccov_options=""
-    if [[ $xccovarchive_file == *".xcresult"* ]]; then
-      xccov_options="--archive"
-    fi
-    xcrun xccov view $xccov_options --file-list "$xccovarchive_file" | while read -r file_name; do
-      convert_file "$xccovarchive_file" "$file_name" "$xccov_options"
-    done
+    convert_archive "$xccovarchive_file"
   done
   echo '</coverage>'
 }
@@ -66,42 +43,9 @@ function check_xcode_version {
   echo $xcode_major_version
 }
 
-function cleanup_tmp_files {
-  rm -rf tmp.json
-  rm -rf tmp.xccovarchive
-}
-
-# Optimize coverage files conversion time by exporting to a clean xcodearchive directory
-# Credits to silverhammermba on issue #68 for the suggestion
-function optimize_format {
-  cleanup_tmp_files
-  xcrun xcresulttool get --format json --path "$xccovarchive_file" > tmp.json
-  if [ $? -ne 0 ]; then 
-    echo 'Failed to execute xcrun xcresulttool get' 1>&2
-    exit -1
-  fi
-
-  # local reference=$(jq -r '.actions._values[2].actionResult.coverage.archiveRef.id._value'  tmp.json)
-  local reference=$(jq -r '.actions._values[]|[.actionResult.coverage.archiveRef.id],._values'  tmp.json | grep value | cut -d : -f 2 | cut -d \" -f 2)
-  if [ $? -ne 0 ]; then 
-    echo 'Failed to execute jq (https://stedolan.github.io/jq/)' 1>&2
-    exit -1
-  fi
-  # $reference can be a list of IDs (from a merged .xcresult bundle of multiple test plans)
-  for test_ref in $reference; do
-    xcrun xcresulttool export --type directory --path "$xccovarchive_file" --id "$test_ref" --output-path tmp.xccovarchive
-    if [ $? -ne 0 ]; then 
-      echo "Failed to execute xcrun xcresulttool export for reference ${test_ref}" 1>&2
-      exit -1
-    fi
-  done
-  echo "tmp.xccovarchive"
-}
-
 xcode_version=$(check_xcode_version)
 if [ $? -ne 0 ]; then
   exit -1
 fi
 
 xccov_to_generic "$@"
-cleanup_tmp_files


### PR DESCRIPTION
The conversion script tends to be too slow on big projects because the coverage data extraction is done file by file. This pull request removes the iteration and changes the conversion to work with a single extraction command. The transformation is now also handling the `&` characters in filenames and escapes them properly in XML.
The change has been tested with Xcode 13 and Xcode 14. So to avoid regressions on older versions of Xcode, it has been restricted to versions 13 and beyond.

Also as part of this PR, the script doesn't merge multiple Xcode test results into a single XML file anymore as this could lead to incorrect results when there are multiple xcresult folders for the same tests. Instead, you can pass a comma-separated list of XML report files to the `sonar.coverageReportPaths` option.

The problem with the escaping of `&` was reported in [this community topic](https://community.sonarsource.com/t/files-folder-with-special-characters-in-names-causing-syntactically-incorrect-xml/79498/7) and is being tracked by this JIRA [ticket](https://sonarsource.atlassian.net/browse/SONARSWIFT-538).