### PR TITLE
Update instructions for scanner for Gradle 5.0.0.4638

### DIFF
--- a/sonar-scanner-gradle/gradle-basic/README.md
+++ b/sonar-scanner-gradle/gradle-basic/README.md
@@ -11,13 +11,22 @@ Run the following command (updating the sonar.host.url property as appropriate):
 
 * On Unix-like systems:
   ```text
-  ./gradlew -Dsonar.host.url=http://myhost:9000 sonar
+  ./gradlew build -Dsonar.host.url=http://myhost:9000 sonar
   ```
 * On Windows:
   ```text
-  .\gradlew.bat -D'sonar.host.url=http://myhost:9000' sonar
+  .\gradlew.bat build -D'sonar.host.url=http://myhost:9000' sonar
   ```
 
 ## Coverage
 
 To get the project [test coverage](https://community.sonarsource.com/t/coverage-test-data-importing-jacoco-coverage-report-in-xml-format) computed, add gradle task `jacocoTestReport` to your command line.
+
+* On Unix-like systems:
+  ```text
+  ./gradlew build jacocoTestReport -Dsonar.host.url=http://myhost:9000 sonar
+  ```
+* On Windows:
+  ```text
+  .\gradlew.bat build jacocoTestReport -D'sonar.host.url=http://myhost:9000' sonar
+  ```

--- a/sonar-scanner-gradle/gradle-basic/build.gradle
+++ b/sonar-scanner-gradle/gradle-basic/build.gradle
@@ -2,7 +2,7 @@ plugins {
     id "jacoco"
     id "java"
     id "application"
-    id("org.sonarqube") version "4.4.1.3373"
+    id("org.sonarqube") version "5.0.0.4638"
 }
 
 description = 'Example of SonarScanner for Gradle Usage'

--- a/sonar-scanner-gradle/gradle-kotlin-dsl/build.gradle.kts
+++ b/sonar-scanner-gradle/gradle-kotlin-dsl/build.gradle.kts
@@ -6,7 +6,7 @@ plugins {
     jacoco
     `java-library`
     id("org.flywaydb.flyway") version "9.20.0"
-    id("org.sonarqube") version "4.4.1.3373"
+    id("org.sonarqube") version "5.0.0.4638"
     id("org.gradle.maven-publish") // Noncompliant - kotlin:S6634 Core plugins IDs should be replaced by their shortcuts
 }
 

--- a/sonar-scanner-gradle/gradle-multimodule-coverage/README.md
+++ b/sonar-scanner-gradle/gradle-multimodule-coverage/README.md
@@ -24,7 +24,7 @@ Here are the important changes compared to the original Gradle sample project li
 * add reference to the SonarScanner for Gradle to the root `build.gradle`:
   ```groovy
   plugins {
-    id "org.sonarqube" version "4.3.1.3277"
+    id "org.sonarqube" version "5.0.0.4638"
   }
   ```
 * add the following to `subprojects{}` block of root `build.gradle`:

--- a/sonar-scanner-gradle/gradle-multimodule-coverage/build.gradle
+++ b/sonar-scanner-gradle/gradle-multimodule-coverage/build.gradle
@@ -1,7 +1,7 @@
 plugins {
     id 'java'
     id 'jacoco'
-    id "org.sonarqube" version "4.4.1.3373"
+    id "org.sonarqube" version "5.0.0.4638"
 }
 
 allprojects {

--- a/sonar-scanner-gradle/gradle-multimodule/README.md
+++ b/sonar-scanner-gradle/gradle-multimodule/README.md
@@ -14,11 +14,11 @@ Run the following command (updating the sonar.host.url property as appropriate):
 * On Unix-like systems:
 
 ```shell
-  ./gradlew -Dsonar.host.url=http://myhost:9000 sonar
+  ./gradlew build -Dsonar.host.url=http://myhost:9000 sonar
 ```
 
 * On Windows:
 
 ```powershell
-  .\gradle.bat -Dsonar.host.url=http://myhost:9000 sonar
+  .\gradle.bat build -Dsonar.host.url=http://myhost:9000 sonar
 ```

--- a/sonar-scanner-gradle/gradle-multimodule/build.gradle
+++ b/sonar-scanner-gradle/gradle-multimodule/build.gradle
@@ -1,6 +1,6 @@
 plugins {
     id "java-library"
-    id "org.sonarqube" version "4.4.1.3373"
+    id "org.sonarqube" version "5.0.0.4638"
 }
 
 allprojects {


### PR DESCRIPTION
As of version 5.0 pf the scanner for Gradle, compilation task are no longer implicitly called before analysis.

For this reason, it is advised to add a task that compiles the code and generates class files for a more accurate analysis.