### PR TITLE
add ! to fix logic

### DIFF
--- a/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
+++ b/swift-coverage/swift-coverage-example/xccov-to-sonarqube-generic.sh
@@ -25,7 +25,7 @@ function check_xcode_version() {
 if ! xcode_version="$(xcodebuild -version | sed -n '1s/^Xcode \([0-9.]*\)$/\1/p')"; then
   echo 'Failed to get Xcode version' 1>&2
   exit 1
-elif check_xcode_version ${xcode_version//./ }; then
+elif ! check_xcode_version ${xcode_version//./ }; then
   echo "Xcode version '$xcode_version' not supported, version 13.3 or above is required" 1>&2;
   exit 1
 fi


### PR DESCRIPTION
Currently the logic for checking the xcode version is flipped, thus exiting with status code 1 when the xcode_version is supported (13.3 or above). This pull request fixes this issue.