### PR TITLE
Use SonarScanner CLI for the Ant project instead of deprecated Ant Scanner

### DIFF
--- a/NOTICE.txt
+++ b/NOTICE.txt
@@ -1,5 +1,5 @@
 sonar-scanning-examples
-Copyright (C) 2016-2017 SonarSource SA
+Copyright (C) 2016-2025 SonarSource SA
 mailto:info AT sonarsource DOT com
 
 This product includes software developed at

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This repository showcases basic examples of usage and code coverage for SonarSca
 * [SonarScanner for Gradle](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-gradle)
 * [SonarScanner for .NET](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-dotnet)
 * [SonarScanner for Maven](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-maven)
-* [SonarScanner for Ant](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-ant) - This scanner is now deprecated. See link for more details.
+* SonarScanner CLI in a Java Ant project (Formerly [SonarScanner for Ant](https://docs.sonarsource.com/sonarqube/9.9/analyzing-source-code/scanners/sonarscanner-for-ant) - This scanner is now deprecated. See link for more details)
 * [SonarScanner CLI](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner)
 
 Sonar's [Clean Code solution](https://www.sonarsource.com/solutions/clean-code/) helps developers deliver high-quality, efficient code standards that benefit the entire team or organization. 
@@ -14,9 +14,12 @@ Sonar's [Clean Code solution](https://www.sonarsource.com/solutions/clean-code/)
 * [SonarScanner for various languages](sonar-scanner)
 
 ### Ant
-[SonarScanner for Ant](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-ant) is now deprecated. Please migrate to the SonarScanner CLI.
+Scaning an Ant project is no different than scanning a plain Java (no build tool) project. Ant is used to build the project, but not to run the scan. Instead, the SonarScanner CLI is used.
 * [SonarScanner for Ant - Basic](sonar-scanner-ant/ant-basic)
 * [SonarScanner for Ant - Code Coverage](sonar-scanner-ant/ant-coverage)
+
+[SonarScanner for Ant](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-ant) is now deprecated. Please migrate to the SonarScanner CLI.
+
 
 ### Gradle
 If you have a Gradle project, we recommend usage of [SonarScanner for Gradle](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-gradle) or the equivalent SonarScanner for Gradle on your CI pipeline.
@@ -42,6 +45,6 @@ If you have a .NET project, we recommend the usage of [SonarScanner for .NET](ht
 **_NOTE:_** All SonarScanner examples for C, C++ and Objective-C can be found [here](https://github.com/sonarsource-cfamily-examples).
 
 ## License
-Copyright 2016-2023 SonarSource.
+Copyright 2016-2025 SonarSource.
 
 Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)

--- a/sonar-scanner-ant/ant-basic/README.md
+++ b/sonar-scanner-ant/ant-basic/README.md
@@ -1,17 +1,14 @@
-# SonarScanner for Ant is deprecated on SonarCloud and as of SonarQube 9.9. Please see [Moving from SonarScanner for Ant to SonarScanner](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-ant/#moving-from-sonarscanner-for-ant-to-sonarscanner) documentation for how to migrate to the SonarScanner.
+# SonarScanner CLI on a Java Ant project
 
-# SonarScanner for Ant
-
-This example demonstrates how to analyze a simple Apache Ant project with SonarScanner for Ant.
+This example demonstrates how to analyze a simple Apache Ant project with SonarScanner CLI. SonarScanner for Ant is deprecated on SonarCloud and as of SonarQube 9.9, therefore this is the current way of scanning an Ant project. Please see [Moving from SonarScanner for Ant to SonarScanner](https://docs.sonarsource.com/sonarqube/9.9/analyzing-source-code/scanners/sonarscanner-for-ant/#moving-from-sonarscanner-for-ant-to-sonarscanner) documentation for how to migrate to the SonarScanner.
 
 ## Prerequisites
-* [SonarScanner for Ant](http://redirect.sonarsource.com/doc/ant-task.html) 2.7.1 or higher
+* [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/) 
 * [Ant](http://ant.apache.org/) 1.10.0 or higher
 
 ## Usage
-1. Set the path to the SonarQube Ant Task in the build.xml file
-2. Set the URL of your SonarQube instance in the property 'sonar.host.url'
-3. Run the following command:
-    ```shell
-    ant all
-    ```
+1. Compile the project:
+   ```shell
+   ant all
+   ```
+2. Run SonarScanner CLI.

--- a/sonar-scanner-ant/ant-basic/build.xml
+++ b/sonar-scanner-ant/ant-basic/build.xml
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project name="Simple Project analyzed with the SonarQube Scanner for Ant" default="all" basedir="." xmlns:sonar="antlib:org.sonar.ant">
+<project name="Ant Project analyzed with SonarScanner CLI" default="all" basedir="." xmlns:sonar="antlib:org.sonar.ant">
 
 	<!-- ========= Define the main properties of this project ========= -->
 	<property name="src.dir" value="src" />
@@ -8,14 +8,6 @@
 
 	<!-- Define the SonarQube global properties (the most usual way is to pass these properties via the command line) -->
 	<property name="sonar.host.url" value="http://localhost:9000" />
-
-	<!-- Define the Sonar properties -->
-	<property name="sonar.projectKey" value="org.sonarqube:sonar-scanner-ant" />
-	<property name="sonar.projectName" value="Example of SonarQube Scanner for Ant Usage" />
-	<property name="sonar.projectVersion" value="1.0" />
-	<property name="sonar.sources" value="src" />
-	<property name="sonar.binaries" value="target" />
-	<property name="sonar.sourceEncoding" value="UTF-8" />
 
 	<!-- ========= Define "regular" targets: clean, compile, ... ========= -->
 	<target name="clean">
@@ -31,18 +23,7 @@
 		<javac srcdir="${src.dir}" destdir="${classes.dir}" fork="true" debug="true" includeAntRuntime="false" />
 	</target>
 
-	<!-- ========= Define SonarQube Scanner for Ant Target ========= -->
-	<target name="sonar" depends="compile">
-		<taskdef uri="antlib:org.sonar.ant" resource="org/sonar/ant/antlib.xml">
-			<!-- Update the following line, or put the "sonar-ant-task-*.jar" file in your "$HOME/.ant/lib" folder -->
-			<classpath path="path/to/sonar/ant/task/lib/sonarqube-ant-task-*.jar" />
-		</taskdef>
-
-		<!-- Execute SonarQube Scanner for Ant Analysis -->
-		<sonar:sonar />
-	</target>
-
 	<!-- ========= The main target "all" ========= -->
-	<target name="all" depends="clean,compile,sonar" />
+	<target name="all" depends="clean,compile" />
 
 </project>

--- a/sonar-scanner-ant/ant-basic/sonar-project.properties
+++ b/sonar-scanner-ant/ant-basic/sonar-project.properties
@@ -1,0 +1,6 @@
+sonar.projectKey=org.sonarqube:sonar-scanner-ant
+sonar.projectName=Example of SonarScanner CLI on Ant project
+sonar.projectVersion=1.0
+sonar.sources=src
+sonar.java.binaries=target
+sonar.sourceEncoding=UTF-8

--- a/sonar-scanner-ant/ant-coverage/README.md
+++ b/sonar-scanner-ant/ant-coverage/README.md
@@ -1,8 +1,6 @@
-# SonarScanner for Ant is deprecated on SonarCloud and as of SonarQube 9.9. Please see [Moving from SonarScanner for Ant to SonarScanner](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-ant/#moving-from-sonarscanner-for-ant-to-sonarscanner) documentation for how to migrate to the SonarScanner.
+# SonarScanner CLI on a Java Ant project with JaCoCo Coverage
 
-# SonarScanner Ant with JaCoCo Coverage
-
-This example demonstrates how to analyze a simple project with Apache Ant and JaCoCo coverage. Code example is derived from [JaCoCo's own repository of examples](https://github.com/jacoco/jacoco/tree/v0.8.7/org.jacoco.examples/build).
+This example demonstrates how to analyze a simple project with Apache Ant and JaCoCo coverage. Code example is derived from [JaCoCo's own repository of examples](https://github.com/jacoco/jacoco/tree/v0.8.7/org.jacoco.examples/build). SonarScanner for Ant is deprecated on SonarCloud and as of SonarQube 9.9, therefore this is the current way of scanning an Ant project. Please see [Moving from SonarScanner for Ant to SonarScanner](https://docs.sonarsource.com/sonarqube/9.9/analyzing-source-code/scanners/sonarscanner-for-ant/#moving-from-sonarscanner-for-ant-to-sonarscanner) documentation for how to migrate to the SonarScanner.
 
 The JaCoCo coverage report is imported via the following Sonar scanner analysis parameter `sonar.coverage.jacoco.xmlReportPaths` (see [Test Coverage & Execution Overview](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/test-coverage/overview/)):
 
@@ -13,17 +11,16 @@ The JaCoCo coverage report is imported via the following Sonar scanner analysis 
 For more details on JaCoCo integration with Ant, see [JaCoCo Ant Tasks](https://www.eclemma.org/jacoco/trunk/doc/ant.html).
 
 ## Prerequisites
-* [SonarScanner for Ant](http://redirect.sonarsource.com/doc/ant-task.html) 2.7.1 or higher
+* [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/latest/analyzing-source-code/scanners/sonarscanner/) 
 * [Ant](http://ant.apache.org/) 1.10.0 or higher
 * [JaCoCo](https://www.eclemma.org/jacoco/) 0.8.7 or higher
   * You can find Jacoco artifacts by version [here](https://repo1.maven.org/maven2/org/jacoco/jacoco/). Once unzipped, look for lib/jacocoant.jar
 
 ## Usage
-1. Set the path to the SonarQube Ant Task (jar) in the build.xml file.
-2. Set the path to the JaCoCo Ant Task (jar) in the build.xml file.
-3. Set the path to the JaCoCo XML report, if necessary. The default is set to `${result.report.dir}/report.xml` in the build.xml file.
-4. Set the URL of your SonarQube instance in the property 'sonar.host.url'
-5. Run the following command:
-    ```shell
-    ant rebuild -Dsonar.login=<INSERT-LOGIN-TOKEN>
-    ```
+1. Set the path to the JaCoCo Ant Task (jar) in the build.xml file.
+2. Set the path to the JaCoCo XML report, if necessary. The default is set to `${result.report.dir}/report.xml` in the build.xml file.
+3. Compile the project:
+   ```shell
+   ant rebuild
+   ```
+4. Run SonarScanner CLI.

--- a/sonar-scanner-ant/ant-coverage/build.xml
+++ b/sonar-scanner-ant/ant-coverage/build.xml
@@ -16,8 +16,7 @@
 
 	<description>
 	  Example Ant build file that demonstrates how a JaCoCo coverage report
-	  can be integrated into an existing build in three simple steps with
-	  SonarQube Sonar Scanner for Ant.
+	  can be integrated into an existing build with SonarScanner CLI for an Ant project.
 	</description>
 
 	<property name="src.dir" location="./src/main/java" />
@@ -25,14 +24,6 @@
 	<property name="result.classes.dir" location="${result.dir}/classes" />
 	<property name="result.report.dir" location="${result.dir}/site/jacoco" />
 	<property name="result.exec.file" location="${result.dir}/jacoco.exec" />
-
-	<!-- SonarQube -->
-	<property name="sonar.projectKey" value="org.sonarqube:sonar-scanner-ant-coverage" />
-	<property name="sonar.projectName" value="Example of Ant and JaCoCo Usage" />
-	<property name="sonar.host.url" value="http://localhost:9000" />
-	<property name="sonar.sources" value="src" />
-	<property name="sonar.java.binaries" value="target" />
-	<property name="sonar.coverage.jacoco.xmlReportPaths" value="${result.report.dir}/report.xml" />
 
 	<!-- Step 1: Import JaCoCo Ant tasks -->
 	<taskdef uri="antlib:org.jacoco.ant" resource="org/jacoco/ant/antlib.xml">
@@ -90,17 +81,6 @@
 		</jacoco:report>
 	</target>
 
-	<!-- ========= Define SonarQube Scanner for Ant Target ========= -->
-	<target name="sonar" depends="compile">
-		<taskdef uri="antlib:org.sonar.ant" resource="org/sonar/ant/antlib.xml">
-			<!-- Update the following line, or put the "sonar-ant-task-*.jar" file in your "$HOME/.ant/lib" folder -->
-			<classpath path="path/to/sonar/ant/task/lib/sonarqube-ant-task-*.jar" />
-		</taskdef>
-
-		<!-- Execute SonarQube Scanner for Ant Analysis -->
-		<sonar:sonar />
-	</target>
-
-	<target name="rebuild" depends="clean,compile,test,report,sonar" />
+	<target name="rebuild" depends="clean,compile,test,report" />
 
 </project>

--- a/sonar-scanner-ant/ant-coverage/sonar-project.properties
+++ b/sonar-scanner-ant/ant-coverage/sonar-project.properties
@@ -1,0 +1,7 @@
+sonar.projectKey=org.sonarqube:sonar-scanner-ant-coverage
+sonar.projectName=Example of SonarScanner CLI on Ant project with JaCoCo coverage
+sonar.projectVersion=1.0
+sonar.sources=src
+sonar.java.binaries=target
+sonar.sourceEncoding=UTF-8
+sonar.coverage.jacoco.xmlReportPaths=target/site/jacoco/report.xml


### PR DESCRIPTION
I was answering a ticket where they asked how to set up the Scanner on an Ant project. Since the Scanner for Ant is deprecated, it's just a matter of setting up the Scanner CLI in the same way you would for a plain Java project. 

I did it just to try it out for the customer, and then thought that it might be nice to actually have this example here. It could potentially deflect more tickets like this, or just help us answer them.

Essentially what I've done is just moving the `sonar.*` properties from `build.xml` to `sonar-project.properties`.