### PR TITLE
Fix gradle default main source set

### DIFF
--- a/sonar-scanner-gradle/gradle-basic/build.gradle
+++ b/sonar-scanner-gradle/gradle-basic/build.gradle
@@ -12,8 +12,7 @@ sonar {
     properties {
         property('sonar.projectName', 'Example of SonarScanner for Gradle Usage')
         property("sonar.projectKey", "sonar-scanner-gradle")
-        property("sonar.sources", "src/main")
-        property "sonar.tests", "src/test"
+
     }
 }
 
@@ -39,7 +38,6 @@ java {
     toolchain {
         languageVersion = JavaLanguageVersion.of(17)
     }
-    sourceSets.main.java.srcDirs = ['src']
 }
 
 application {


### PR DESCRIPTION
`sourceSets.main.java.srcDirs = ['src']` was overriding the gradle default (`src/main/java`) and therefore making it necessary to pass the scanner the otherwise superfluous prop `property("sonar.sources", "src/main")`.