### PR TITLE
Use correct property for multimodule jacoco report

### DIFF
--- a/sonar-scanner-maven/maven-multimodule/README.md
+++ b/sonar-scanner-maven/maven-multimodule/README.md
@@ -13,7 +13,6 @@ Build the project, execute all the tests, and analyze it with SonarScanner for M
 
 ```shell
 mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:5.6.0.6792:sonar \
-  -Dsonar.coverage.jacoco.xmlReportPaths=$(pwd)/tests/target/site/jacoco-aggregate/jacoco.xml \
   -Dsonar.junit.reportPaths=target/surefire-reports
 ```
 
@@ -83,14 +82,14 @@ To import it into SonarQube, set the path in the top-level `pom.xml`:
 
 ```
 <properties>
-  <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+  <sonar.coverage.jacoco.aggregateXmlReportPaths>${maven.multiModuleProjectDirectory}/tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.aggregateXmlReportPaths>
 </properties>
 ```
 
 Or pass it directly via the command line:
 
 ```
--Dsonar..coverage.jacoco.xmlReportPaths=absolute/path/to/jacoco.xml
+-Dsonar.coverage.jacoco.aggregateXmlReportPaths=absolute/path/to/jacoco.xml
 ```
 
 ## Unit Test Result Reporting

--- a/sonar-scanner-maven/maven-multimodule/pom.xml
+++ b/sonar-scanner-maven/maven-multimodule/pom.xml
@@ -21,7 +21,7 @@
     <project.reporting.outputEncoding>UTF-8</project.reporting.outputEncoding>
     <maven.compiler.target>1.8</maven.compiler.target>
     <maven.compiler.source>1.8</maven.compiler.source>
-    <sonar.coverage.jacoco.xmlReportPaths>${maven.multiModuleProjectDirectory}/tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.xmlReportPaths>
+    <sonar.coverage.jacoco.aggregateXmlReportPaths>${maven.multiModuleProjectDirectory}/tests/target/site/jacoco-aggregate/jacoco.xml</sonar.coverage.jacoco.aggregateXmlReportPaths>
   </properties>
 
   <dependencies>


### PR DESCRIPTION
[Docs](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/test-coverage/java-test-coverage#multi-module-maven-project) say to use `sonar.coverage.jacoco.aggregateXmlReportPaths`, and [some side effects seem to happen when you use the wrong prop](https://community.sonarsource.com/t/sonar-multimodule-with-coverage-logging-file-filename-not-found-in-project-sources/181980/10).