### PR TITLE
[CONTENT-3798] README update for marketing

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,89 +2,57 @@
   <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/82c13eba-d95c-4bb8-8007-7ce77c14e043/Sonar_Logo_Light%20Backgrounds.svg" alt="Sonar logo" width="400">
 </p>
 
-# SonarScanner examples
+# Sonar Scanning Examples
 
-This repository provides small projects that show how to configure and run SonarScanners across common build tools, languages, and coverage workflows. Each example is a focused reference that can be compared with the corresponding setup in your own project.
+This repository showcases basic examples of usage and code coverage for SonarScanners.
+* [SonarScanner for Gradle](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-gradle)
+* [SonarScanner for .NET](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/dotnet/introduction)
+* [SonarScanner for Maven](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-maven)
+* SonarScanner CLI in a Java Ant project (Formerly [SonarScanner for Ant](https://docs.sonarsource.com/sonarqube-server/10.8/analyzing-source-code/scanners/sonarscanner-for-ant) - this scanner is now deprecated, use SonarScanner CLI)
+* [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner)
 
-[![GitHub stars](https://img.shields.io/github/stars/SonarSource/sonar-scanning-examples?style=flat)](https://github.com/SonarSource/sonar-scanning-examples)
-[![License](https://img.shields.io/badge/license-LGPL--3.0-blue)](#license)
-[![Community forum](https://img.shields.io/badge/community-forum-blue)](https://community.sonarsource.com/)
-
-## What you can learn
-
-- Configure SonarScanner for Gradle, Maven, .NET, and CLI projects.
-- Scan projects in several languages and build environments.
-- Import test coverage into SonarQube analysis.
-- Use SonarScanner CLI with older Ant projects.
-- Use the examples as a starting point for a CI verification loop.
 
 ## Examples
+### Various Languages
+[SonarScanner for various languages](sonar-scanner)
 
-- [Various languages](sonar-scanner)
-- SonarScanner CLI in an Ant project:
-  - [Basic](sonar-scanner-ant/ant-basic)
-  - [Code coverage](sonar-scanner-ant/ant-coverage)
-- SonarScanner for Gradle:
-  - [Basic](sonar-scanner-gradle/gradle-basic)
-  - [Kotlin DSL](sonar-scanner-gradle/gradle-kotlin-dsl)
-  - [Kotlin](sonar-scanner-gradle/gradle-kotlin-project)
-  - [Multi-module](sonar-scanner-gradle/gradle-multimodule)
-  - [Multi-module code coverage](sonar-scanner-gradle/gradle-multimodule-coverage)
-- SonarScanner for Maven:
-  - [Basic](sonar-scanner-maven/maven-basic)
-  - [Multilingual Java and Kotlin with coverage](sonar-scanner-maven/maven-multilingual)
-  - [Multi-module](sonar-scanner-maven/maven-multimodule)
-- [SonarScanner for .NET](sonar-scanner-dotnet/CSharpProject)
-- [Swift coverage](swift-coverage)
-- [C, C++, and Objective-C examples](https://github.com/sonarsource-cfamily-examples)
+Scan all the languages available or change directory to a language folder to scan just that language.
 
-The repository also includes focused examples for Gradle multi-module builds, Kotlin DSL, Maven multi-module projects, Java and Kotlin coverage, and .NET projects. Each example contains the project files and scanner configuration needed to reproduce the analysis.
+### Ant
+Scanning an Ant project is no different than scanning a plain Java (no build tool) project. Ant is used to build the project, but not to run the scan. Instead, the SonarScanner CLI is used.
+* [SonarScanner for Ant - Basic](sonar-scanner-ant/ant-basic)
+* [SonarScanner for Ant - Code Coverage](sonar-scanner-ant/ant-coverage)
 
-The Ant scanner is deprecated. Use [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner) or the scanner that matches your build system.
+[SonarScanner for Ant](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-ant) is now deprecated. Please migrate to the SonarScanner CLI.
 
-## Quick start
 
-Clone the repository and open the example that matches your build system:
+### Gradle
+If you have a Gradle project, we recommend the use of [SonarScanner for Gradle](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-gradle) or the equivalent `gradle sonar` task in your CI pipeline.
+* [SonarScanner for Gradle - Basic](sonar-scanner-gradle/gradle-basic)
+* [SonarScanner for Gradle - Kotlin DSL with build.gradle.kts](sonar-scanner-gradle/gradle-kotlin-dsl)
+* [SonarScanner for Gradle - Kotlin](sonar-scanner-gradle/gradle-kotlin-project)
+* [SonarScanner for Gradle - Multi-Module](sonar-scanner-gradle/gradle-multimodule)
+* [SonarScanner for Gradle - Multi-Module Code Coverage](sonar-scanner-gradle/gradle-multimodule-coverage)
 
-```bash
-git clone https://github.com/SonarSource/sonar-scanning-examples.git
-cd sonar-scanning-examples
-```
+### Maven
+If you have a Maven project, we recommend the use of [SonarScanner for Maven](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-maven) or the equivalent `mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` goal in your CI pipeline.
+* [SonarScanner for Maven - Basic](sonar-scanner-maven/maven-basic)
+* [SonarScanner for Maven - Multilingual (Java + Kotlin with coverage)](sonar-scanner-maven/maven-multilingual)
+* [SonarScanner for Maven - Multi-Module](sonar-scanner-maven/maven-multimodule)
 
-Follow the example's local README to configure its scanner for [SonarQube Server](https://www.sonarsource.com/products/sonarqube/server/) or [SonarQube Cloud](https://www.sonarsource.com/products/sonarqube/cloud/). The analysis results will appear in the SonarQube project configured by that example. Start with the [scanner documentation](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners) if you have not yet created a project or token.
+### DotNet/C#
+If you have a .NET project, we recommend the use of [SonarScanner for .NET](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/dotnet/introduction) or the equivalent SonarScanner for .NET on your CI pipeline.
+* [SonarScanner for .NET/MSBuild - C#](sonar-scanner-dotnet/CSharpProject)
 
-For example, after configuring the target URL and token, run the basic Maven project with:
+### Swift
+[SonarScanner - Swift Code Coverage](swift-coverage)
 
-```bash
-cd sonar-scanner-maven/maven-basic
-mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
-```
-
-For Gradle, use the `sonar` task. For Maven, use the Sonar Maven plugin goal. For .NET, follow the begin, build, and end steps in the SonarScanner for .NET documentation. For a project without a supported build integration, use SonarScanner CLI.
-
-## Links
-
-- [Scanner documentation](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners)
-- [Community forum](https://community.sonarsource.com/)
-- [Report an issue](https://github.com/SonarSource/sonar-scanning-examples/issues)
-- [Contributing](#contributing)
-- [Security policy](https://www.sonarsource.com/trust-center/)
-- [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner)
-
-## FAQ
-
-**Which example should I start with?** Use the scanner that matches your build system: Gradle, Maven, or .NET. Use SonarScanner CLI for projects without a supported build-system integration.
-
-## Contributing
-
-If you find an example that is out of date or unclear, open an issue or pull request with the relevant tool version, SonarQube product, and expected result. Keep examples small and copy-paste friendly.
+### C/C++/Objective-C
+**_NOTE:_** All SonarScanner examples for C, C++ and Objective-C can be found [here](https://github.com/sonarsource-cfamily-examples).
+* SonarSource sample C and C++ projects with SonarQube Cloud or SonarQube Server analysis configured
+* C and C++ projects for different CI pipelines and build systems configured for Linux, Windows, and Mac
 
 ## License
-
 Copyright 2016-2026 SonarSource.
 
-Licensed under the [GNU Lesser General Public License, Version 3.0](https://www.gnu.org/licenses/lgpl-3.0.txt).
-
-## Get started
-
-Choose a [scanner example](#examples), then follow the matching [scanner documentation](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners).
+Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)

--- a/README.md
+++ b/README.md
@@ -1,55 +1,90 @@
-# Sonar Scanning Examples
+<p align="center">
+  <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/82c13eba-d95c-4bb8-8007-7ce77c14e043/Sonar_Logo_Light%20Backgrounds.svg" alt="Sonar logo" width="400">
+</p>
 
-This repository showcases basic examples of usage and code coverage for SonarScanners.
-* [SonarScanner for Gradle](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-gradle)
-* [SonarScanner for .NET](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/dotnet/introduction)
-* [SonarScanner for Maven](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-maven)
-* SonarScanner CLI in a Java Ant project (Formerly [SonarScanner for Ant](https://docs.sonarsource.com/sonarqube-server/10.8/analyzing-source-code/scanners/sonarscanner-for-ant) - this scanner is now deprecated, use SonarScanner CLI)
-* [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner)
+# SonarScanner examples
 
-Sonar's [Clean Code solution](https://www.sonarsource.com/solutions/clean-code/) helps developers deliver high-quality, efficient code standards that benefit the entire team or organization. 
+This repository provides small projects that show how to configure and run SonarScanners across common build tools, languages, and coverage workflows. Each example is a focused reference that can be compared with the corresponding setup in your own project.
+
+[![GitHub stars](https://img.shields.io/github/stars/SonarSource/sonar-scanning-examples?style=flat)](https://github.com/SonarSource/sonar-scanning-examples)
+[![License](https://img.shields.io/badge/license-LGPL--3.0-blue)](#license)
+[![Community forum](https://img.shields.io/badge/community-forum-blue)](https://community.sonarsource.com/)
+
+## What you can learn
+
+- Configure SonarScanner for Gradle, Maven, .NET, and CLI projects.
+- Scan projects in several languages and build environments.
+- Import test coverage into SonarQube analysis.
+- Use SonarScanner CLI with older Ant projects.
+- Use the examples as a starting point for a CI verification loop.
 
 ## Examples
-### Various Languages
-[SonarScanner for various languages](sonar-scanner)
 
-Scan all the languages available or change directory to a language folder to scan just that language.
+- [Various languages](sonar-scanner)
+- SonarScanner CLI in an Ant project:
+  - [Basic](sonar-scanner-ant/ant-basic)
+  - [Code coverage](sonar-scanner-ant/ant-coverage)
+- SonarScanner for Gradle:
+  - [Basic](sonar-scanner-gradle/gradle-basic)
+  - [Kotlin DSL](sonar-scanner-gradle/gradle-kotlin-dsl)
+  - [Kotlin](sonar-scanner-gradle/gradle-kotlin-project)
+  - [Multi-module](sonar-scanner-gradle/gradle-multimodule)
+  - [Multi-module code coverage](sonar-scanner-gradle/gradle-multimodule-coverage)
+- SonarScanner for Maven:
+  - [Basic](sonar-scanner-maven/maven-basic)
+  - [Multilingual Java and Kotlin with coverage](sonar-scanner-maven/maven-multilingual)
+  - [Multi-module](sonar-scanner-maven/maven-multimodule)
+- [SonarScanner for .NET](sonar-scanner-dotnet/CSharpProject)
+- [Swift coverage](swift-coverage)
+- [C, C++, and Objective-C examples](https://github.com/sonarsource-cfamily-examples)
 
-### Ant
-Scanning an Ant project is no different than scanning a plain Java (no build tool) project. Ant is used to build the project, but not to run the scan. Instead, the SonarScanner CLI is used.
-* [SonarScanner for Ant - Basic](sonar-scanner-ant/ant-basic)
-* [SonarScanner for Ant - Code Coverage](sonar-scanner-ant/ant-coverage)
+The repository also includes focused examples for Gradle multi-module builds, Kotlin DSL, Maven multi-module projects, Java and Kotlin coverage, and .NET projects. Each example contains the project files and scanner configuration needed to reproduce the analysis.
 
-[SonarScanner for Ant](https://docs.sonarsource.com/sonarqube/latest/analyzing-source-code/scanners/sonarscanner-for-ant) is now deprecated. Please migrate to the SonarScanner CLI.
+The Ant scanner is deprecated. Use [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner) or the scanner that matches your build system.
 
+## Quick start
 
-### Gradle
-If you have a Gradle project, we recommend the use of [SonarScanner for Gradle](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-gradle) or the equivalent `gradle sonar` task in your CI pipeline.
-* [SonarScanner for Gradle - Basic](sonar-scanner-gradle/gradle-basic)
-* [SonarScanner for Gradle - Kotlin DSL with build.gradle.kts](sonar-scanner-gradle/gradle-kotlin-dsl)
-* [SonarScanner for Gradle - Kotlin](sonar-scanner-gradle/gradle-kotlin-project)
-* [SonarScanner for Gradle - Multi-Module](sonar-scanner-gradle/gradle-multimodule)
-* [SonarScanner for Gradle - Multi-Module Code Coverage](sonar-scanner-gradle/gradle-multimodule-coverage)
+Clone the repository and open the example that matches your build system:
 
-### Maven
-If you have a Maven project, we recommend the use of [SonarScanner for Maven](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-maven) or the equivalent `mvn org.sonarsource.scanner.maven:sonar-maven-plugin:sonar` goal in your CI pipeline.
-* [SonarScanner for Maven - Basic](sonar-scanner-maven/maven-basic)
-* [SonarScanner for Maven - Multilingual (Java + Kotlin with coverage)](sonar-scanner-maven/maven-multilingual)
-* [SonarScanner for Maven - Multi-Module](sonar-scanner-maven/maven-multimodule)
+```bash
+git clone https://github.com/SonarSource/sonar-scanning-examples.git
+cd sonar-scanning-examples
+```
 
-### DotNet/C#
-If you have a .NET project, we recommend the use of [SonarScanner for .NET](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/dotnet/introduction) or the equivalent SonarScanner for .NET on your CI pipeline.
-* [SonarScanner for .NET/MSBuild - C#](sonar-scanner-msbuild/CSharpProject)
+Follow the example's local README to configure its scanner for [SonarQube Server](https://www.sonarsource.com/products/sonarqube/server/) or [SonarQube Cloud](https://www.sonarsource.com/products/sonarqube/cloud/). The analysis results will appear in the SonarQube project configured by that example. Start with the [scanner documentation](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners) if you have not yet created a project or token.
 
-### Swift
-[SonarScanner - Swift Code Coverage](swift-coverage)
+For example, after configuring the target URL and token, run the basic Maven project with:
 
-### C/C++/Objective-C
-**_NOTE:_** All SonarScanner examples for C, C++ and Objective-C can be found [here](https://github.com/sonarsource-cfamily-examples).
-* SonarSource sample C and C++ projects with SonarCloud or SonarQube analysis configured
-* C and C++ projects for different CI pipelines and build systems configured for Linux, Windows, and Mac
+```bash
+cd sonar-scanner-maven/maven-basic
+mvn clean verify org.sonarsource.scanner.maven:sonar-maven-plugin:sonar
+```
+
+For Gradle, use the `sonar` task. For Maven, use the Sonar Maven plugin goal. For .NET, follow the begin, build, and end steps in the SonarScanner for .NET documentation. For a project without a supported build integration, use SonarScanner CLI.
+
+## Links
+
+- [Scanner documentation](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners)
+- [Community forum](https://community.sonarsource.com/)
+- [Report an issue](https://github.com/SonarSource/sonar-scanning-examples/issues)
+- [Contributing](#contributing)
+- [Security policy](https://www.sonarsource.com/trust-center/)
+- [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner)
+
+## FAQ
+
+**Which example should I start with?** Use the scanner that matches your build system: Gradle, Maven, or .NET. Use SonarScanner CLI for projects without a supported build-system integration.
+
+## Contributing
+
+If you find an example that is out of date or unclear, open an issue or pull request with the relevant tool version, SonarQube product, and expected result. Keep examples small and copy-paste friendly.
 
 ## License
+
 Copyright 2016-2026 SonarSource.
 
-Licensed under the [GNU Lesser General Public License, Version 3.0](http://www.gnu.org/licenses/lgpl.txt)
+Licensed under the [GNU Lesser General Public License, Version 3.0](https://www.gnu.org/licenses/lgpl-3.0.txt).
+
+## Get started
+
+Choose a [scanner example](#examples), then follow the matching [scanner documentation](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners).

--- a/README.md
+++ b/README.md
@@ -11,7 +11,6 @@ This repository showcases basic examples of usage and code coverage for SonarSca
 * SonarScanner CLI in a Java Ant project (Formerly [SonarScanner for Ant](https://docs.sonarsource.com/sonarqube-server/10.8/analyzing-source-code/scanners/sonarscanner-for-ant) - this scanner is now deprecated, use SonarScanner CLI)
 * [SonarScanner CLI](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner)
 
-
 ## Examples
 ### Various Languages
 [SonarScanner for various languages](sonar-scanner)

--- a/README.md
+++ b/README.md
@@ -1,10 +1,13 @@
 <p align="center">
-  <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/82c13eba-d95c-4bb8-8007-7ce77c14e043/Sonar_Logo_Light%20Backgrounds.svg" alt="Sonar logo" width="400">
+  <picture>
+    <source media="(prefers-color-scheme: dark)" srcset="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/a23fc7ba-23f0-489a-829d-ed88c0748521/Sonar_Logo_Dark%20Backgrounds.svg">
+    <img src="https://assets-eu-01.kc-usercontent.com/ef593040-b591-0198-9506-ed88b30bc023/82c13eba-d95c-4bb8-8007-7ce77c14e043/Sonar_Logo_Light%20Backgrounds.svg" alt="Sonar logo" width="400">
+  </picture>
 </p>
 
 # Sonar Scanning Examples
 
-This repository showcases basic examples of usage and code coverage for SonarScanners.
+This repository contains practical examples for running SonarScanners and importing code coverage across multiple languages and build systems.
 * [SonarScanner for Gradle](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-gradle)
 * [SonarScanner for .NET](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/dotnet/introduction)
 * [SonarScanner for Maven](https://docs.sonarsource.com/sonarqube-server/analyzing-source-code/scanners/sonarscanner-for-maven)


### PR DESCRIPTION
## Summary

This draft makes a deliberately small README update:

- Adds the shared Sonar logo
- Removes the retired Clean Code marketing paragraph
- Repairs the outdated .NET example path
- Uses the current SonarQube Cloud and SonarQube Server product names

The repository's existing scanner documentation, commands, example navigation, and usage guidance are otherwise preserved.

## Review guidance

These README changes were automatically generated using the [shared README guidelines](https://github.com/SonarSource/sonar-readme-updates/blob/6edffcf04d8f1c3cb61e63b26b82a3d9ce721cc7/README-guidelines.md). The guidelines link is internal to Sonar.

Please review the changes carefully for repository-specific accuracy before approving them. In particular, please check:

- The four changes described above
- The corrected .NET example path
- Logo and README rendering in GitHub light and dark modes

## Validation

- Reconciled with `master` at `5cf3c9d551f1d13ddae1b8d8a2ec936678d8a6a2`
- Restored the upstream technical content and structure
- Verified the corrected .NET example path against the current repository tree
- Verified the CDN-hosted logo URL
- Passed the configured commit checks

This is a documentation-only change and does not modify runtime code.


## Tracking

Jira epic: [CONTENT-3798](https://sonarsource.atlassian.net/browse/CONTENT-3798)


[CONTENT-3798]: https://sonarsource.atlassian.net/browse/CONTENT-3798?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ